### PR TITLE
show only overdue reminder on 'RT at a glance' page

### DIFF
--- a/share/html/Elements/MyReminders
+++ b/share/html/Elements/MyReminders
@@ -51,7 +51,7 @@
     title => loc("My reminders"),
     title_href => RT->Config->Get('WebPath') . '/Tools/MyReminders.html' &>
 
-<& /Elements/ShowReminders &>
+<& /Elements/ShowReminders, OnlyOverdue => 1 &>
 
 </&>
 


### PR DESCRIPTION
This revert partly commit 01bef109.
On the 'RT at a glance' page you will see only the most important
reminders (that are overdue or without an due date).
If you want to see all your reminder you can click on the 'My reminders'
title or got to Tools->My reminders.
