### PR TITLE
add Resolve action to Ticket.html

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -3058,6 +3058,16 @@ sub Steal {
 
 
 
+=head2 Resolve
+
+A convenience method to change the current ticket's status to Resolved
+
+=cut
+
+sub Resolve {
+    my $self = shift;
+    return ( $self->SetStatus( 'resolved' ));
+}
 
 
 =head2 ValidateStatus STATUS

--- a/share/html/Ticket/Display.html
+++ b/share/html/Ticket/Display.html
@@ -140,7 +140,7 @@ if ($ARGS{'id'} eq 'new') {
         TicketObj => $TicketObj, Tickets => $Tickets,
         ActionsRef => \@Actions, ARGSRef => \%ARGS );
     if ( defined $ARGS{'Action'} ) {
-        if ($ARGS{'Action'} =~ /^(Steal|Delete|Take|SetTold)$/) {
+        if ($ARGS{'Action'} =~ /^(Steal|Resolve|Delete|Take|SetTold)$/) {
             my $action = $1;
             my ($res, $msg) = $TicketObj->$action();
             push(@Actions, $msg);


### PR DESCRIPTION
Allows user to pass `Resolve` as action in URL to `Ticket.html`, to resolve a ticket without adding comments.
Useful for providing a link in emails, to resolve quickly when customer emails back a "thank-you" or similar.
