### PR TITLE
Unify address checking

### DIFF
--- a/share/html/REST/1.0/Forms/ticket/default
+++ b/share/html/REST/1.0/Forms/ticket/default
@@ -56,6 +56,7 @@ $args => undef
 <%INIT>
 use MIME::Entity;
 use RT::Interface::REST;
+use RT::User;
 
 my $cf_spec = RT::Interface::REST->custom_field_spec(1);
 
@@ -325,11 +326,9 @@ else {
                 }
             }
             foreach $p (keys %new) {
-                # XXX: This is a stupid test.
-                unless ($p =~ /^[\w.+-]+\@([\w.-]+\.)*\w+.?$/) {
-                    $s = 0;
-                    $n = "$p is not a valid email address.";
-                    push @msgs, [ $s, $n ];
+                my ($ok, $error) = RT::User->CheckEmailAddress($p);
+                unless ($ok) {
+                    push @msgs, [ $ok, $error ];
                     next;
                 }
                 unless ($ticket->IsWatcher(Type => $type, Email => $p)) {


### PR DESCRIPTION
This is an attempt to fix an issue I'm having creating tickets by the REST interface - the parsing and validation of email addresses appears overly strict, and there is a FIXME type comment to that effect.

I've changed it to use the generic validation routine in RT::User by splitting a method in half.

The exception we were getting back is:

Cc: glen.d'souza@demonmusicgroup.co.uk is not a valid email address.

which is clearly from the code I've fixed, although I'm unsure that how I've fixed it is correct.

Please take a look.
Cheers
t0m