### PR TITLE
Fix uninitialized value warnings with StatementLog on, issue #19119.

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -1072,7 +1072,7 @@ sub LogRecordedSQLStatements {
             message => "SQL("
                 . sprintf( "%.6f", $duration )
                 . "s): $sql;"
-                . ( @bind ? "  [ bound values: @{[map{qq|'$_'|} @bind]} ]" : "" )
+                . ( @bind ? "  [ bound values: @{[map{ defined $_ ? qq|'$_'| : 'undef'} @bind]} ]" : "" )
         );
     }
 


### PR DESCRIPTION
Fix for http://issues.bestpractical.com/Ticket/Display.html?id=19119

Another very minor bug, but I'm seeing uninitialized value warnings when StatementLog is enabled and I access a page like Ticket/ModifyPeople.html which has undef bind values.

[Thu Dec 22 02:36:40 2011] [warning]: Use of uninitialized value $_ in concatenation (.) or string at /usr/lib/rt4/RT/Interface/Web.pm line 1059. (/usr/lib/rt4/RT/Interface/Web.pm:1064)
[Thu Dec 22 02:36:40 2011] [warning]: Use of uninitialized value $_ in concatenation (.) or string at /usr/lib/rt4/RT/Interface/Web.pm line 1059. (/usr/lib/rt4/RT/Interface/Web.pm:1064)
[Thu Dec 22 02:36:40 2011] [warning]: Use of uninitialized value $_ in concatenation (.) or string at /usr/lib/rt4/RT/Interface/Web.pm line 1059. (/usr/lib/rt4/RT/Interface/Web.pm:1064)
