### PR TITLE
This modification will add two new fields one-time-CC and one-time-bCC t...

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -1367,6 +1367,8 @@ sub CreateTicket {
         Cc              => $ARGS{'Cc'},
         AdminCc         => $ARGS{'AdminCc'},
         InitialPriority => $ARGS{'InitialPriority'},
+        UpdateCc        => $ARGS{'UpdateCc'};
+        UpdateBcc       => $ARGS{'UpdateBcc'};
         FinalPriority   => $ARGS{'FinalPriority'},
         TimeLeft        => $ARGS{'TimeLeft'},
         TimeEstimated   => $ARGS{'TimeEstimated'},
@@ -1454,8 +1456,6 @@ sub CreateTicket {
         $create_args{ $map{$key} } = [ grep $_, split ' ', $ARGS{$key} ];
 
     }
-
-    $create_args{'UpdateCc'} = $ARGS{'UpdateCc'};
 
     my ( $id, $Trans, $ErrMsg ) = $Ticket->Create(%create_args);
     unless ($id) {

--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -1455,6 +1455,8 @@ sub CreateTicket {
 
     }
 
+    $create_args{'UpdateCc'} = $ARGS{'UpdateCc'};
+
     my ( $id, $Trans, $ErrMsg ) = $Ticket->Create(%create_args);
     unless ($id) {
         Abort($ErrMsg);

--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -670,6 +670,16 @@ sub Create {
         );
     }
 
+    foreach my $type (qw/Cc Bcc/) {
+        if ( defined $args{ 'Update' . $type } ) {
+
+            my $addresses = join ', ', (
+                map { RT::User->CanonicalizeEmailAddress( $_->address ) }
+                    Email::Address->parse( $args{ 'Update' . $type } ) );
+            $args{'MIMEObj'}->head->replace( 'RT-Send-' . $type, Encode::encode_utf8( $addresses ) );
+        }
+    }
+
     if ( $args{'_RecordTransaction'} ) {
 
         # Add a transaction for the create

--- a/share/html/Ticket/Create.html
+++ b/share/html/Ticket/Create.html
@@ -152,6 +152,11 @@
   </td>
 </tr>
 
+<tr><td class="label"><&|/l&>One-time Cc</&>:</td><td><& /Elements/EmailInput, Name => 'UpdateCc', Size => undef, Default => $ARGS{UpdateCc} &><br />
+</td></tr>
+<tr><td class="label"><&|/l&>One-time Bcc</&>:</td><td><& /Elements/EmailInput, Name => 'UpdateBcc', Size => undef, Default => $ARGS{UpdateBcc} &><br />
+</td></tr>
+
 <tr>
 <td class="label">
 <&|/l&>Subject</&>:


### PR DESCRIPTION
...o the create ticket page.

We regulary need this to send one-time e-mail from the created ticket.
The very same functionality exists when you comment or correspont to an existing ticket.

Signed-off-by: Kadar Attila <atus@mithrandir.hu>

    modified:   lib/RT/Interface/Web.pm
    modified:   lib/RT/Ticket.pm
    modified:   share/html/Ticket/Create.html