### PR TITLE
show header in EmailRecord transactions

### DIFF
--- a/share/html/Ticket/Elements/ShowTransaction
+++ b/share/html/Ticket/Elements/ShowTransaction
@@ -70,7 +70,7 @@
 % if ( $type_class eq 'message' ) {
       <& /Elements/ShowCustomFields, Object => $Transaction &>
 % }
-% $m->comp('ShowTransactionAttachments', %ARGS, Parent => 0) unless ($Collapsed ||!$ShowBody);
+% $m->comp('ShowTransactionAttachments', %ARGS, Parent => 0, ShowBody => $ShowBody) unless $Collapsed;
     </div>
 </div>
 </div>

--- a/share/html/Ticket/Elements/ShowTransactionAttachments
+++ b/share/html/Ticket/Elements/ShowTransactionAttachments
@@ -59,6 +59,8 @@ foreach my $message ( grep $_->__Value('Parent') == $Parent, @$Attachments ) {
               DisplayHeaders => \@DisplayHeaders,
             );
 
+    next unless $ShowBody;
+
     my $size = $message->ContentLength;
     my $name = defined $message->Filename && length $message->Filename ?  $message->Filename : '';
     if ( $size ) {


### PR DESCRIPTION
You can't really call it a bug as nobody missed it the last 8 years.
But I created the patch against stable instead of master because I hope this comes with the next (4.0.8) release or even can make it in 4.0.7, as it is very useful for the normal user to see the recipients of an outgoing email in the history instead of searching within the email header.
