### PR TITLE
re-add attributes to fix IE layout

### DIFF
--- a/share/html/Elements/CollectionList
+++ b/share/html/Elements/CollectionList
@@ -111,7 +111,7 @@ if ($Class =~ /::/) { # older passed in value
     $Class =~ s/:/_/g;
 }
 
-$m->out('<table class="' .
+$m->out('<table border="0" cellspacing="0" cellpadding="1" class="' .
 	($Collection->isa('RT::Tickets') ? 'ticket-list' : 'collection') . ' collection-as-table">');
 
 if ( $ShowHeader ) {


### PR DESCRIPTION
We still need border, cellspacing and cellpadding attributes to show the
collection list in IE (at least IE7) in the same layout as in other
browsers.

This partly reverts commit f5aa30c9.
