### PR TITLE
run scrip which condition isn't UserDefined only on tickets of type tick...

### DIFF
--- a/lib/RT/Scrip.pm
+++ b/lib/RT/Scrip.pm
@@ -408,9 +408,21 @@ sub IsApplicable {
 	    );
 
             if ( $ConditionObj->IsApplicable() ) {
-	        # We found an application Transaction -- return it
-                $return = $TransactionObj;
-                last;
+                # run scrip which condition isn't UserDefined only on tickets of type ticket
+                if ( $ConditionObj->ExecModule ne 'UserDefined'
+                  && $args{'TicketObj'}->Type ne 'ticket' ) {
+                    $RT::Logger->debug("We don't run scrip "
+                        . $self->Id
+                        . " which condition isn't UserDefined on ticket "
+                        . $args{'TicketObj'}->Id
+                        . " of type "
+                        . $args{'TicketObj'}->Type
+                    );
+                } else {
+	                # We found an application Transaction -- return it
+                    $return = $TransactionObj;
+                    last;
+                }
             }
 	}
     };


### PR DESCRIPTION
...et

With this change the predefined conditions in the select list are only
applicable on tickets of type ticket as the condition description notes.

For example:
On an vanilla RT installation if you create an reminder the queue AdminCcs are
notified because of the 'On Create Notify AdminCcs' scrip which isn't always
the desired behavior.

If you want to run an scrip on other than tickets you have to use
the UserDefined condition and can control in custom condition on
which ticket types this scrip should run.
