### PR TITLE
Fix for typo

### DIFF
--- a/lib/RT/Tickets.pm
+++ b/lib/RT/Tickets.pm
@@ -2186,7 +2186,7 @@ sub LimitType {
         VALUE       => $args{'VALUE'},
         OPERATOR    => $args{'OPERATOR'},
         DESCRIPTION => join( ' ',
-            $self->loc('Type'), $args{'OPERATOR'}, $args{'Limit'}, ),
+            $self->loc('Type'), $args{'OPERATOR'}, $args{'VALUE'}, ),
     );
 }
 


### PR DESCRIPTION
The typo was generating some 'Use of uninitialized value in join or string'
