### PR TITLE
EncodeToMIME Dashboard mail subject

### DIFF
--- a/lib/RT/Dashboard/Mailer.pm
+++ b/lib/RT/Dashboard/Mailer.pm
@@ -342,7 +342,7 @@ sub EmailDashboard {
     my $entity = $self->BuildEmail(
         %args,
         To      => $email,
-        Subject => $subject,
+        Subject => RT::Interface::Email::EncodeToMIME( String => $subject ),
     );
 
     $entity->head->replace('X-RT-Dashboard-Id', $dashboard->Id);


### PR DESCRIPTION
This is necessary because the dashboard name can contain non ASCII letters.
