### PR TITLE
Allow RT::Users->WhoBelongToGroups to optionally return  unprivileged users (4.0)

### DIFF
--- a/lib/RT/Users.pm
+++ b/lib/RT/Users.pm
@@ -542,21 +542,31 @@ sub WhoHaveGroupRight
 }
 
 
-=head2 WhoBelongToGroups { Groups => ARRAYREF, IncludeSubgroupMembers => 1 }
+=head2 WhoBelongToGroups { Groups => ARRAYREF, IncludeSubgroupMembers => 1, IncludeUnprivileged => 0 }
+
+Return members who belong to any of the groups passed in the groups whose IDs
+are included in the Groups arrayref.
+
+If IncludeSubgroupMembers is true (default) then members of any group that's a
+member of one of the passed groups are returned. If it's cleared then only
+direct member users are returned.
+
+If IncludeUnprivileged is false (default) then only privileged members are
+returned; otherwise either privileged or unprivileged group members may be
+returned.
 
 =cut
 
-# XXX: should be generalized
 sub WhoBelongToGroups {
     my $self = shift;
     my %args = ( Groups                 => undef,
                  IncludeSubgroupMembers => 1,
+                 IncludeUnprivileged    => 0,
                  @_ );
 
-    # Unprivileged users can't be granted real system rights.
-    # is this really the right thing to be saying?
-    $self->LimitToPrivileged();
-
+    if (!$args{'IncludeUnprivileged'}) {
+        $self->LimitToPrivileged();
+    }
     my $group_members = $self->_JoinGroupMembers( %args );
 
     foreach my $groupid (@{$args{'Groups'}}) {


### PR DESCRIPTION
The WhoBelongToGroups filter should really not apply LimitToPrivileged at
all, but we can't remove it without breaking security assumptions elsewhere
in RT or in 3rd party code. So a new option IncludeUnprivileged is added, a
boolean that defaults to false. It can be set to true to disable the
LimitToPrivileged filter.

The documentation of the method is amended to explain that it filters out
unprivileged members by default.

See http://issues.bestpractical.com/Ticket/Display.html?id=23089