### PR TITLE
Show friendly string instead of "0" for non-ticket "local" links in search results

### DIFF
--- a/share/html/Elements/RT__Ticket/ColumnMap
+++ b/share/html/Elements/RT__Ticket/ColumnMap
@@ -68,7 +68,7 @@ my $LinkCallback = sub {
             \'<a href="',
             $_->$mode_uri->Resolver->HREF,
             \'">',
-            ( $_->$mode_uri->IsLocal ? $_->$local_type : $_->$mode ),
+            ( $_->$mode_uri->IsLocal && $_->$local_type ? $_->$local_type : $_->$mode_uri->Resolver->AsString ),
             \'</a><br />',
         } @{ $_[0]->Links($other_mode,$type)->ItemsArrayRef }
     }

--- a/t/web/search_linkdisplay.t
+++ b/t/web/search_linkdisplay.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+
+use RT::Test tests => 14;
+my ( $baseurl, $m ) = RT::Test->started_ok;
+
+my $ticket = RT::Test->create_ticket(
+    Queue   => 'General',
+    Subject => 'ticket foo',
+);
+
+my $generic_url = 'http://generic_url.example.com';
+my $link = RT::Link->new( RT->SystemUser );
+my ($id,$msg) = $link->Create( Base => $ticket->URI, Target => $generic_url, Type => 'RefersTo' );
+ok($id, $msg);
+
+
+my $ticket2 = RT::Test->create_ticket(
+    Queue   => 'General',
+    Subject => 'ticket bar',
+);
+
+$link = RT::Link->new( RT->SystemUser );
+($id,$msg) = $link->Create( Base => $ticket->URI, Target => $ticket2->URI, Type => 'RefersTo' );
+ok($id, $msg);
+
+
+
+my $class = RT::Class->new( RT->SystemUser );
+($id, $msg) = $class->Create( Name => 'Test Class' );
+ok ($id, $msg);
+
+my $article = RT::Article->new( RT->SystemUser );
+($id, $msg) = $article->Create( Class => $class->Name, Summary => 'Test Article' );
+ok ($id, $msg);
+$article->Load($id);
+
+
+$link = RT::Link->new( RT->SystemUser );
+($id,$msg) = $link->Create( Base => $ticket->URI, Target => $article->URI, Type => 'RefersTo' );
+ok($id, $msg);
+
+
+ok( $m->login, 'logged in' );
+
+$m->get_ok("/Search/Results.html?Format=id,RefersTo;Query=id=".$ticket->Id);
+
+$m->title_is( 'Found 1 ticket', 'title' );
+
+my $ref = $m->find_link( url_regex => qr!generic_url! );
+ok( $ref, "found generic link" );
+is( $ref->text, $generic_url, $generic_url . " is displayed" );
+
+$ref = $m->find_link( url_regex => qr!/Ticket/Display.html! );
+ok( $ref, "found ticket link" );
+is( $ref->text, $ticket2->Id, $ticket2->Id . " is displayed" );
+
+$ref = $m->find_link( url_regex => qr!/Article/Display.html! );
+ok( $ref, "found article link" );
+is( $ref->text, $article->URIObj->Resolver->AsString, $article->URIObj->Resolver->AsString . " is displayed" );


### PR DESCRIPTION
When displaying links in search results, the RT::Ticket ColumnMap assumes all "local" links are tickets, and shows the LocalBase or LocalTarget field as the link text. Therefore "0" is always displayed for local objects which are not tickets (like Articles).

To fix this, Local{Base,Target} should only be used when the linked item is a ticket.
For other links, we should show either the raw URI itself, or the friendly string defined by the URI resolver.
This patch shows the friendly string (which falls back to the raw URI for non-objects).

The included test checks link display behavior for 3 basic links: generic URLs, tickets, and articles.

see https://github.com/AssetTracker/rt-extension-assettracker/issues/42
