### PR TITLE
remove parentheses in RequestorTicketListFormat

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -1388,7 +1388,7 @@ Control the appearance of the ticket lists in the 'More About Requestors' box.
 
 Set($MoreAboutRequestorTicketListFormat, q{
        '<a href="__WebPath__/Ticket/Display.html?id=__id__">__id__</a>',
-       '(__Owner__)',
+       '__Owner__',
        '<a href="__WebPath__/Ticket/Display.html?id=__id__">__Subject__</a>',
        '__Status__',
 });


### PR DESCRIPTION
This is an leftover from the old days where the ticket list where just strings
and not a collection list.
