### PR TITLE
Allow non-interactive database upgrades via --upgrade-from and --upgrade-to in rt-setup-database

### DIFF
--- a/sbin/rt-setup-database.in
+++ b/sbin/rt-setup-database.in
@@ -91,6 +91,7 @@ GetOptions(
     'force', 'debug',
     'dba=s', 'dba-password=s', 'prompt-for-dba-password', 'package=s',
     'datafile=s', 'datadir=s', 'skip-create', 'root-password-file=s',
+    'upgrade-from=s', 'upgrade-to=s',
     'help|h',
 );
 
@@ -318,7 +319,7 @@ sub action_upgrade {
         } else {
             print "Enter $args{package} version you're upgrading from: ";
         }
-        $upgrading_from = scalar <STDIN>;
+        $upgrading_from = $args{'upgrade-from'} || scalar <STDIN>;
         chomp $upgrading_from;
         $upgrading_from =~ s/\s+//g;
     } while $upgrading_from !~ /$version_dir/;
@@ -352,7 +353,7 @@ sub action_upgrade {
                 print "\nEnter $args{package} version if you want to stop upgrade at some point,\n";
                 print "  or leave it blank if you want apply above upgrades: ";
             }
-            $custom_upgrading_to = scalar <STDIN>;
+            $custom_upgrading_to = $args{'upgrade-to'} || scalar <STDIN>;
             chomp $custom_upgrading_to;
             $custom_upgrading_to =~ s/\s+//g;
             last unless $custom_upgrading_to;
@@ -592,5 +593,13 @@ administrator privileges
 
 for 'init' and 'insert': rather than using the default administrative password
 for RT's "root" user, use the password in this file.
+
+=item upgrade-from
+
+for upgrades, specify the version to upgrade from, and do not prompt for it if it appears to be a valid version.
+
+=item upgrade-to
+
+for upgrades, specify the version to upgrade to, and do not prompt for it if it appears to be a valid version.
 
 =back


### PR DESCRIPTION
This patch adds the repeatable, scriptable upgrades for testing upgrading.  This adds two switches to rt-setup-database:

--upgrade-from - Specify the release version to start applying upgrade content
--upgrade-to   - Specify the release version to stop applying upgrade content
