### PR TITLE
Fix RT::Template->Create to return failure message if requested when called.

### DIFF
--- a/lib/RT/Template.pm
+++ b/lib/RT/Template.pm
@@ -256,7 +256,7 @@ sub Create {
         $args{'Queue'} = $QueueObj->Id;
     }
 
-    my $result = $self->SUPER::Create(
+    my ( $result, $msg ) = $self->SUPER::Create(
         Content     => $args{'Content'},
         Queue       => $args{'Queue'},
         Description => $args{'Description'},
@@ -264,7 +264,11 @@ sub Create {
         Type        => $args{'Type'},
     );
 
-    return ($result);
+    if ( wantarray ) {
+    	return ( $result, $msg );
+    } else {
+    	return ( $result );
+    }
 
 }
 


### PR DESCRIPTION
Manifests itself in the following error upgrading from rt-3.6.11 to rt-4.0.18:

[critical]: The 'message' parameter (undef) to Log::Dispatch::Output::log was an 'undef', which is not one of the allowed types: scalar
 at /usr/lib/perl5/site_perl/5.8.8/Params/ValidatePP.pm line 634
    Params::Validate::**ANON**('The \'message\' parameter (undef) to Log::Dispatch::Output::l...') called at /usr/lib/perl5/site_perl/5.8.8/Params/ValidatePP.pm line 485
    Params::Validate::_validate_one_param('undef', 'HASH(0x109ddae0)', 'HASH(0x109ed380)', 'The \'message\' parameter (undef)') called at /usr/lib/perl5/site_perl/5.8.8/Params/ValidatePP.pm line 345
    Params::Validate::validate('ARRAY(0xe57f0f0)', 'HASH(0xe5fa000)') called at /usr/lib/perl5/site_perl/5.8.8/Log/Dispatch/Output.pm line 39
    Log::Dispatch::Output::log('undef', 'level', 'error', 'name', 'screen', 'message', 'undef') called at /usr/lib/perl5/site_perl/5.8.8/Log/Dispatch.pm line 214
    Log::Dispatch::_log_to('Log::Dispatch=HASH(0xe587980)', 'level', 'error', 'name', 'screen', 'message', 'undef') called at /usr/lib/perl5/site_perl/5.8.8/Log/Dispatch.pm line 167
    Log::Dispatch::_log_to_outputs('Log::Dispatch=HASH(0xe587980)', 'level', 'error', 'message', 'undef') called at /usr/lib/perl5/site_perl/5.8.8/Log/Dispatch.pm line 145
    Log::Dispatch::log('Log::Dispatch=HASH(0xe587980)', 'level', 'error', 'message', 'undef') called at /usr/lib/perl5/site_perl/5.8.8/Log/Dispatch.pm line 42
    Log::Dispatch::__ANON__('Log::Dispatch=HASH(0xe587980)', 'undef') called at /app/int-rt-stage/sbin/../lib/RT/Handle.pm line 1034
    RT::Handle::InsertData('RT::Handle=HASH(0xdd73600)', './etc/upgrade/3.7.10/content', 'undef') called at /app/int-rt-stage/sbin/rt-setup-database line 298
    main::action_insert('datafile', 'undef', 'datadir', './etc/upgrade/3.7.10', 'backcompat', 'ARRAY(0xb988e20)', 'force', 1, 'package', ...) called at /app/int-rt-stage/sbin/rt-setup-database line 404
