### PR TITLE
Call the proper module in DependencyWalker.pm

### DIFF
--- a/lib/RT/DependencyWalker.pm
+++ b/lib/RT/DependencyWalker.pm
@@ -51,7 +51,7 @@ package RT::DependencyWalker;
 use strict;
 use warnings;
 
-use RT::DependencyWalker::Dependencies;
+use RT::DependencyWalker::FindDependencies;
 use Carp;
 
 sub new {


### PR DESCRIPTION
$ git grep -h ^package lib/RT/DependencyWalker/Dependencies.pm
package RT::DependencyWalker::FindDependencies;
$
