### PR TITLE
Adds missing use LWP::MediaTypes statement for guess_media_type

### DIFF
--- a/lib/RT/Interface/REST.pm
+++ b/lib/RT/Interface/REST.pm
@@ -47,6 +47,7 @@
 # END BPS TAGGED BLOCK }}}
 
 package RT::Interface::REST;
+use LWP::MediaTypes qw(guess_media_type);
 use strict;
 use warnings;
 use RT;


### PR DESCRIPTION
It would appear that the factoring of the attachment processing code in the REST interface in commit 7b6ddfb did not include the use statement for guess_media_type.  The consequence being if you post attachments without content-type, RT errors and includes a Perl traceback in the API response.
