### PR TITLE
Allow grouping by custom field name in addition to id

### DIFF
--- a/lib/RT/Report/Tickets.pm
+++ b/lib/RT/Report/Tickets.pm
@@ -168,6 +168,7 @@ our %GROUPINGS_META = (
             $CustomFields->LimitToGlobal;
             while ( my $CustomField = $CustomFields->Next ) {
                 push @res, ["Custom field", $CustomField->Name], "CF.{". $CustomField->id ."}";
+                push @res, ["Custom field", $CustomField->Name], "CF.{". $CustomField->Name ."}";
             }
             return @res;
         },


### PR DESCRIPTION
In 4.1 you could use GroupBy with a custom field name. The current code filters this out.
