### PR TITLE
Set proper alias for custom field in query

### DIFF
--- a/lib/RT/Report/Tickets.pm
+++ b/lib/RT/Report/Tickets.pm
@@ -762,7 +762,9 @@ sub GenerateCustomFieldFunction {
         @args{qw(FUNCTION FIELD)} = ('NULL', undef);
     } else {
         my ($ticket_cf_alias, $cf_alias) = $self->_CustomFieldJoin($cf->id, $cf);
-        @args{qw(ALIAS FIELD)} = ($ticket_cf_alias, 'Content');
+        my $mangled_name = $cf->Name;
+        $mangled_name =~ s/\W/_/g;
+        @args{qw(AS ALIAS FIELD)} = ('CF_'.$mangled_name, $ticket_cf_alias, 'Content');
     }
     return %args;
 }


### PR DESCRIPTION
DBIx::SearchBase sets a column name for each custom field requested in
the query, but this name is neither stable nor really intuitive.  This
patch just sets the name to "CF_$name", with all not applicable
characters replaced.