### PR TITLE
fix ticket link name without rights on target ticket

### DIFF
--- a/share/html/Elements/ShowLink
+++ b/share/html/Elements/ShowLink
@@ -49,7 +49,7 @@
 % if ($URI->IsLocal) {
 % my $member = $URI->Object;
 % my $has_name = UNIVERSAL::can($member, 'Name') || (UNIVERSAL::can($member, '_Accessible') && $member->_Accessible('Name', 'read'));
-% if (UNIVERSAL::isa($member, "RT::Ticket")) {
+% if (UNIVERSAL::isa($member, "RT::Ticket") and $member->CurrentUserHasRight('ShowTicket')) {
 % my $inactive = $member->QueueObj->IsInactiveStatus($member->Status);
 
 <span class="<% $inactive ? 'ticket-inactive' : '' %>">


### PR DESCRIPTION
If you have ticket 1 which is linked to ticket 2 and the user doesn't have
rights for ticket 2 the link is:
`1: [] (owner ticket 2)`
The ticket 2 subject and status isn't displayed because the rights check
but the ticket 2 owner is displayed without any rights check.

Also, if ticket 2 status is closed the class of the span element of the
link isn't set to 'ticket-inactive' because the ticket 2 status value
isn't accessible for the user.

With this commit the link name would fall back to $URI->AsString which shows
only the ticket id (the subject isn't shown in this case).
