### PR TITLE
fix signature in messagebox

### DIFF
--- a/share/html/Ticket/Update.html
+++ b/share/html/Ticket/Update.html
@@ -174,7 +174,7 @@
 <& /Elements/MessageBox, Name=>"UpdateContent", Default=>$ARGS{UpdateContent}, IncludeSignature => 0, %ARGS&>
 % $ARGS{'QuoteTransaction'} = $temp;
 % } else {
-% my $IncludeSignature = 1;
+% my $IncludeSignature = RT->Config->Get('MessageBoxIncludeSignature');
 % $IncludeSignature = 0 if $Action ne 'Respond' && !RT->Config->Get('MessageBoxIncludeSignatureOnComment');
 <& /Elements/MessageBox, Name=>"UpdateContent", IncludeSignature => $IncludeSignature, %ARGS &>
 % }


### PR DESCRIPTION
By setting $IncludeSignature to 1 the signature is always included in the
message box on replies, regardless of the MessageBoxIncludeSignature
setting.
This fixes the bug by respecting the MessageBoxIncludeSignature setting.