### PR TITLE
CSS fix that lets Firefox flow the data table below the chart

### DIFF
--- a/share/static/css/rudder/ticket-lists.css
+++ b/share/static/css/rudder/ticket-lists.css
@@ -174,6 +174,8 @@ div.paging {
 .chart-wrapper .collection-as-table {
     width: auto;
     font-size: 1em;
+    /* Firefox needs this to let the table flow below the chart on narrow screens */
+    clear: right;
 }
 
 .chart-wrapper .collection-as-table th.collection-as-table {


### PR DESCRIPTION
Add the fix from cd0e710b103bb5b23deb32b9dac31f1c1eedaa92 also to rudder.
