### PR TITLE
show reminder without due if $OnlyOverdue is true

### DIFF
--- a/share/html/Elements/ShowReminders
+++ b/share/html/Elements/ShowReminders
@@ -91,7 +91,7 @@ my $tsql = 'Type = "reminder"' .
            ' AND ( Owner = "Nobody" OR Owner ="' . $session{'CurrentUser'}->id . '")' .
            ' AND ( Status = "new" OR Status = "open" )';
 
-$tsql .= ' AND Due < "now"' if $OnlyOverdue;
+$tsql .= ' AND ( Due < "now" OR Due IS NULL )' if $OnlyOverdue;
 
 $reminders->FromSQL($tsql);
 $reminders->OrderBy( FIELD => 'Due', ORDER => 'ASC' );


### PR DESCRIPTION
This restores back the behavior from RT 4.0 to show reminders without due if
$OnlyOverdue is set to true.

e60885aa changed the meaning of "Due < 'now'" to no longer include tickets
whose dates are unset.
