### PR TITLE
tag SystemError transactions with an error class

### DIFF
--- a/lib/RT/Record.pm
+++ b/lib/RT/Record.pm
@@ -1762,6 +1762,7 @@ our %TRANSACTION_CLASSIFICATION = (
             Owner Creator LastUpdatedBy
         ) ),
     },
+    SystemError => 'error',
     __default => 'other',
 );
 

--- a/share/static/css/base/history.css
+++ b/share/static/css/base/history.css
@@ -147,6 +147,7 @@ padding-right:0.25em;
 .transaction.message .type { background: #069; }
 .transaction.reminders .type { background: #369; }
 .transaction.other .type { background: #abc; }
+.transaction.error .type { background: #abc; }
 
 
 .transaction .message-header-value.verify { font-weight: bold; }


### PR DESCRIPTION
This makes it easy to make the SystemError transactions more visible to the
user with a little bit of css.
Previously the txn was tagged with the 'other' class.
The new 'error' class use currently the same style as the previous 'other'
class to not surprise the user with an layout change within an stable release.
