### PR TITLE
fix owner dropdown warning for ticket search without queue clause

### DIFF
--- a/share/html/Elements/SelectOwnerDropdown
+++ b/share/html/Elements/SelectOwnerDropdown
@@ -83,8 +83,10 @@ my $dropdown_limit = 50;
 $m->callback( CallbackName => 'ModifyDropdownLimit', DropdownLimit => \$dropdown_limit );
 
 if (keys(%user_uniq_hash) > $dropdown_limit ) {
-    my $desc = $Objects->[0]->RecordType." ".$Objects->[0]->id;
-    RT->Logger->notice("More than $dropdown_limit possible Owners found for $desc; switching to autocompleter");
+    if ($Objects->[0]->id) {
+        my $desc = $Objects->[0]->RecordType." ".$Objects->[0]->id;
+        RT->Logger->notice("More than $dropdown_limit possible Owners found for $desc; switching to autocompleter");
+    }
     $m->comp("/Elements/SelectOwnerAutocomplete", %ARGS);
     return;
 }


### PR DESCRIPTION
3056568 introduced switching to autocompleter if we have more than 50 owners.
The commit missed that Search/Build.html (Search/Elements/PickBasics) also use
the SelectOwner element and pass an empty Queues hash, if the query doesn't have
a queue clause (which is the case if you create a new ticket search).
In the above case the SelectOwner element pass an empty queue object as Objects
to the SelectOwnerDropdown which results in loading every user with OwnTicket
rights.

This commit fixes "Use of uninitialized value in concatenation" warnings on
ticket search without a queue clause in the query.
It also avoids the "More than 50 possible Owners found ..." notice on new
ticket search if you have more than 50 users with the OwnTicket right.
