### PR TITLE
localize the Recursive column title

### DIFF
--- a/share/html/Admin/Elements/MembershipsPage
+++ b/share/html/Admin/Elements/MembershipsPage
@@ -73,7 +73,7 @@
     Order   => 'ASC',
     Rows    => 20,
     %ARGS,
-    DisplayFormat => "__CheckBox.{Add}__,'__HasMemberRecursively.{$id}__/TITLE:$loc_Recursive',$Format",
+    DisplayFormat => "__CheckBox.{Add}__,'__HasMemberRecursively.{$id}__/TITLE:Recursive member',$Format",
     Format => $Format,
     Collection => $is_not_member,
     AllowSorting => 1,
@@ -85,7 +85,6 @@
 </form>
 
 <%INIT>
-my $loc_Recursive = loc('Recursive');
 my $principal = RT::Principal->new( $session{'CurrentUser'} );
 $principal->Load( $id ) || Abort(loc("Couldn't load principal #[_1]", $id));
 


### PR DESCRIPTION
```
modified:   share/html/Admin/Elements/MembershipsPage
```

Is this the simplest way you can localize a table header element?
