### PR TITLE
Ticket graph connection finding/handling patch

### DIFF
--- a/lib/RT/Graph/Tickets.pm
+++ b/lib/RT/Graph/Tickets.pm
@@ -299,9 +299,12 @@ sub TicketLinks {
     }
 
     $args{'Seen'} ||= {};
-    return $args{'Graph'} if $args{'Seen'}{ $args{'Ticket'}->id }++;
-
-    $self->AddTicket( %args );
+    if ( $args{'Seen'}{ $args{'Ticket'}->id } && $args{'Seen'}{ $args{'Ticket'}->id } <= $args{'CurrentDepth'} ) {
+      return $args{'Graph'};
+    } elsif ( ! defined $args{'Seen'}{ $args{'Ticket'}->id } ) {
+      $self->AddTicket( %args );
+    }
+    $args{'Seen'}{ $args{'Ticket'}->id } = $args{'CurrentDepth'};
 
     return $args{'Graph'} if $args{'MaxDepth'} && $args{'CurrentDepth'} >= $args{'MaxDepth'};
 


### PR DESCRIPTION
The original way the ticket links were finded and handled has a flaw. If 
a ticket was reached first in a 'longer' path/way than the shortes way 
from the root ticket, it got a bigger CurrentDepth as it should be. Later 
this ticket were skipped because it was 'already seen' but the 
CurrentDepth were not checked.

To handle connections and CurrentDepth correctly, the whole algorithm 
should be rewriten from depth-first to child-first search.
