### PR TITLE
log more info on scrip run-time warnings

### DIFF
--- a/lib/RT/Scrip.pm
+++ b/lib/RT/Scrip.pm
@@ -625,6 +625,17 @@ sub Prepare {
                  TransactionObj => undef,
                  @_ );
 
+    local $SIG{__WARN__} = sub {
+        $RT::Logger->warning(
+            "#" . $args{'TicketObj'}->Id . "/"
+            . $args{'TransactionObj'}->Id
+            . " - prepare Scrip "
+            . ($self->Id || '#rule') . " "
+            . ($self->Description || '')
+            . ": @_"
+        );
+    };
+
     my $return;
     eval {
         $self->ActionObj->LoadAction(
@@ -658,6 +669,17 @@ sub Commit {
     my %args = ( TicketObj      => undef,
                  TransactionObj => undef,
                  @_ );
+
+    local $SIG{__WARN__} = sub {
+        $RT::Logger->warning(
+            "#" . $args{'TicketObj'}->Id . "/"
+            . $args{'TransactionObj'}->Id
+            . " - commit Scrip "
+            . ($self->Id || '#rule') . " "
+            . ($self->Description || '')
+            . ": @_"
+        );
+    };
 
     my $return;
     eval {


### PR DESCRIPTION
Previously on run-time warnings only the line number is logged which makes it
hard to debug.
With this commit we log ticket id, transaction id and scrip id and name which
gives enough information for debugging.

After this change the following tests fail:
* t/web/crypt-gnupg.t
* t/mail/html-outgoing.t
* t/crypt/smime/bad-recipients.t
* t/crypt/no-signer-address.t

and I actually need some help to make this tests pass.