### PR TITLE
Silence undef warning in Admin/Users/Modify

### DIFF
--- a/share/html/Admin/Users/Modify.html
+++ b/share/html/Admin/Users/Modify.html
@@ -105,7 +105,7 @@
 <br />
 <&| /Widgets/TitleBox, title => loc('Access control'), class => 'user-info-access-control' &>
 <input type="hidden" class="hidden" name="SetEnabled" value="1" />
-<input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked%> />
+<input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked||''%> />
 <label for="Enabled"><&|/l&>Let this user access RT</&></label><br />
 
 


### PR DESCRIPTION
This fixes "Use of uninitialized value $EnabledChecked in join or string"
and was missed in 12d9ef91161e4a6a4515680a9ce9129abca62697.
