### PR TITLE
Silence undef warning in EmailParser

### DIFF
--- a/lib/RT/EmailParser.pm
+++ b/lib/RT/EmailParser.pm
@@ -619,7 +619,7 @@ sub RescueOutlook {
     # Add base64 since we've seen examples of double newlines with
     # this type too. Need an example of a multi-part base64 to
     # handle that permutation if it exists.
-    elsif ( $mime->head->get('Content-Transfer-Encoding') =~ m{base64} ) {
+    elsif ( ($mime->head->get('Content-Transfer-Encoding')||'') =~ m{base64} ) {
         $text_part = $mime;    # Assuming single part, already decoded.
     }
 


### PR DESCRIPTION
For emails without Content-Transfer-Encoding header.
