### PR TITLE
Allow queue id as key for OverrideOutgoingMailFrom hash

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -565,7 +565,7 @@ address of the queue as it is handed to sendmail -f. This helps force
 the From_ header away from www-data or other email addresses that show
 up in the "Sent by" line in Outlook.
 
-The option is a hash reference of queue name to email address.  If
+The option is a hash reference of queue id/name to email address. If
 there is no ticket involved, then the value of the C<Default> key will
 be used.
 

--- a/lib/RT/Interface/Email.pm
+++ b/lib/RT/Interface/Email.pm
@@ -440,14 +440,15 @@ sub SendEmail {
             my $Overrides = RT->Config->Get('OverrideOutgoingMailFrom') || {};
 
             if ($TicketObj) {
-                my $QueueName = $TicketObj->QueueObj->Name;
-                my $QueueAddressOverride = $Overrides->{$QueueName};
+                my $Queue = $TicketObj->QueueObj;
+                my $QueueAddressOverride = $Overrides->{$Queue->id} 
+                    || $Overrides->{$Queue->Name};
 
                 if ($QueueAddressOverride) {
                     $OutgoingMailAddress = $QueueAddressOverride;
                 } else {
-                    $OutgoingMailAddress ||= $TicketObj->QueueObj->CorrespondAddress
-                                             || RT->Config->Get('CorrespondAddress');
+                    $OutgoingMailAddress ||= $Queue->CorrespondAddress
+                        || RT->Config->Get('CorrespondAddress');
                 }
             }
             elsif ($Overrides->{'Default'}) {


### PR DESCRIPTION
A queue name is easily changed within the WebUI and maybe the admin forget to
also update the OverrideOutgoingMailFrom setting. It more reliable to use the
queue id instead the queue name as the hash key.
