### PR TITLE
extract status loc strings from lifecycles instead of static list in Queue.pm

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -2751,9 +2751,9 @@ Such a mapping is defined as follows:
 
 Set(%Lifecycles,
     default => {
-        initial         => [ 'new' ],
-        active          => [ 'open', 'stalled' ],
-        inactive        => [ 'resolved', 'rejected', 'deleted' ],
+        initial         => [qw(new)], # loc_qw
+        active          => [qw(open stalled)], # loc_qw
+        inactive        => [qw(resolved rejected deleted)], # loc_qw
 
         defaults => {
             on_create => 'new',

--- a/lib/RT/Queue.pm
+++ b/lib/RT/Queue.pm
@@ -99,13 +99,6 @@ use RT::Groups;
 use RT::ACL;
 use RT::Interface::Email;
 
-# $self->loc('new'); # For the string extractor to get a string to localize
-# $self->loc('open'); # For the string extractor to get a string to localize
-# $self->loc('stalled'); # For the string extractor to get a string to localize
-# $self->loc('resolved'); # For the string extractor to get a string to localize
-# $self->loc('rejected'); # For the string extractor to get a string to localize
-# $self->loc('deleted'); # For the string extractor to get a string to localize
-
 __PACKAGE__->AddRight( General => SeeQueue            => 'View queue' ); # loc
 __PACKAGE__->AddRight( Admin   => AdminQueue          => 'Create, modify and delete queue' ); # loc
 __PACKAGE__->AddRight( Admin   => ShowACL             => 'Display Access Control List' ); # loc


### PR DESCRIPTION
After this change I run `devel/tools/extract-message-catalog share/po/de.po` to check the extraction and I noticed this changes:

``` diff
-#: lib/RT/Queue.pm:107
+#: etc/RT_Config.pm:2756
 msgid "deleted"
-msgstr "gelöscht"
+msgstr ""

-#: lib/RT/Queue.pm:106
+#: etc/RT_Config.pm:2756
 msgid "rejected"
-msgstr "abgewiesen"
+msgstr ""

-#: lib/RT/Queue.pm:105
+#: etc/RT_Config.pm:2756
 msgid "resolved"
-msgstr "erledigt"
+msgstr ""

-#: lib/RT/Queue.pm:104
+#: etc/RT_Config.pm:2755
 msgid "stalled"
-msgstr "zurückgestellt"
+msgstr ""
```

Maybe there is something wrong with extract-message-catalog?
