### PR TITLE
implement RowsPerPage for external CustomFieldValues

### DIFF
--- a/lib/RT/CustomFieldValues/External.pm
+++ b/lib/RT/CustomFieldValues/External.pm
@@ -196,6 +196,7 @@ sub _DoSearch {
         $value->LoadFromHash( { %defaults, %$_ } );
         next if $check && !$check->( $self, $value );
         $self->AddRecord( $value );
+        last if $self->RowsPerPage and ++$i >= $self->RowsPerPage;
     }
     $self->{'must_redo_search'} = 0;
     return $self->_RecordCount;


### PR DESCRIPTION
This is only for limiting the result set and necessary to make
b22dbbb20d6121a30d502d379c9f34ce61b4fabc work.

$i was already defined but unused.
