### PR TITLE
Fix comment about scrip sort order to match code.

### DIFF
--- a/lib/RT/Scrips.pm
+++ b/lib/RT/Scrips.pm
@@ -439,10 +439,8 @@ sub _SetupSourceObjects {
 
 =head2 _FindScrips
 
-Find only the apropriate scrips for whatever we're doing now.  Order them 
-by their description.  (Most common use case is to prepend a number to the
-description, forcing the scrips to display and run in ascending alphanumerical 
-order.)
+Find only the appropriate scrips for whatever we're doing now.  Order them 
+by the sortorder field from the objectscrips table.
 
 =cut
 


### PR DESCRIPTION
The comment wasn't updated when the concept of objectscrip sortorder was introduced.
