### PR TITLE
Let CF box on Display page link to subsection of editing page

### DIFF
--- a/share/html/Elements/EditCustomFieldCustomGroupings
+++ b/share/html/Elements/EditCustomFieldCustomGroupings
@@ -49,7 +49,7 @@
 <&| /Widgets/TitleBox,
     title => $group? loc($group) : loc('Custom Fields'),
     class => $css_class .' '. ($group? CSSClass("$css_class-$group") : ''),
-    ($group ? (id => CSSClass("$css_class-$group")) : ()),
+    id    => ($group ? CSSClass("$css_class-$group") : $css_class),
     hide_empty => 1,
     %$TitleBoxARGS,
 &>

--- a/share/html/Elements/ShowCustomFieldCustomGroupings
+++ b/share/html/Elements/ShowCustomFieldCustomGroupings
@@ -51,7 +51,7 @@ for my $group ( @Groupings ) {
         title => $group? loc($group) : loc('Custom Fields'),
         class => $css_class .' '. ($group? CSSClass("$css_class-$group") : ''),
         hide_empty => 1,
-        title_href => $title_href ? "$title_href?id=".$Object->id.($group?";Grouping=".$m->interp->apply_escapes($group,'u')."#".CSSClass("$css_class-$group") : '') : undef,
+        title_href => $title_href ? "$title_href?id=".$Object->id.($group?";Grouping=".$m->interp->apply_escapes($group,'u')."#".CSSClass("$css_class-$group") : "#".$css_class) : undef,
         %$TitleBoxARGS,
     );
     $m->callback( CallbackName => 'TitleBox', Object => $Object, Grouping => $group, ARGSRef => \%grouping_args );


### PR DESCRIPTION
Additionally to aca8b3b9cecb55072d5efc0efedbca04e7f2222a for users with lot of
CFs in groups AND CFs not in groups, this lets you jump to the right place
if you choose to edit a CF which isn't in groups.
