### PR TITLE
Fix HTML link target values

### DIFF
--- a/share/html/Elements/MakeClicky
+++ b/share/html/Elements/MakeClicky
@@ -64,7 +64,7 @@ my %actions = (
         my $post = "";
         $post = ")" if $args{value} !~ /\(/ and $args{value} =~ s/\)$//;
         $args{value} = $escaper->($args{value});
-        my $result = qq{[<a target="new" href="$args{value}">}. loc('Open URL') .qq{</a>]};
+        my $result = qq{[<a target="_blank" href="$args{value}">}. loc('Open URL') .qq{</a>]};
         return $args{value} . qq{ <span class="clickylink">$result</span>$post};
     },
     url_overwrite => sub {
@@ -72,7 +72,7 @@ my %actions = (
         my $post = "";
         $post = ")" if $args{value} !~ /\(/ and $args{value} =~ s/\)$//;
         $args{value} = $escaper->($args{value});
-        my $result = qq{<a target="new" href="$args{value}">$args{value}</a>};
+        my $result = qq{<a target="_blank" href="$args{value}">$args{value}</a>};
         return qq{<span class="clickylink">$result</span>$post};
     },
 );

--- a/share/html/Elements/ShowCustomFields
+++ b/share/html/Elements/ShowCustomFields
@@ -100,7 +100,7 @@ my $print_value = sub {
     my $linked = $value->LinkValueTo;
     if ( defined $linked && length $linked ) {
         my $linked = $m->interp->apply_escapes( $linked, 'h' );
-        $m->out('<a href="'. $linked .'" target="_new">');
+        $m->out('<a href="'. $linked .'" target="_blank">');
     }
     my $comp = "ShowCustomField". $cf->Type;
     $m->callback(

--- a/share/html/Install/DatabaseType.html
+++ b/share/html/Install/DatabaseType.html
@@ -58,7 +58,7 @@
 <&|/l&>SQLite is a database that doesn't need a server or any configuration whatsoever. RT's authors recommend it for testing, demoing and development, but it's not quite right for a high-volume production RT server.</&>
 </b></p>
 <p>
-<&|/l_unsafe, '<a href="http://search.cpan.org" target="_new">CPAN</a>' &>If your preferred database isn't listed in the dropdown below, that means RT couldn't find a <i>database driver</i> for it installed locally. You may be able to remedy this by using [_1] to download and install DBD::MySQL, DBD::Oracle or DBD::Pg.</&>
+<&|/l_unsafe, '<a href="http://search.cpan.org" target="_blank">CPAN</a>' &>If your preferred database isn't listed in the dropdown below, that means RT couldn't find a <i>database driver</i> for it installed locally. You may be able to remedy this by using [_1] to download and install DBD::MySQL, DBD::Oracle or DBD::Pg.</&>
 </p>
 </div>
 

--- a/share/html/m/ticket/show
+++ b/share/html/m/ticket/show
@@ -167,7 +167,7 @@ my $print_value = sub {
     my $linked = $value->LinkValueTo;
     if ( defined $linked && length $linked ) {
         my $linked = $m->interp->apply_escapes( $linked, 'h' );
-        $m->out('<a href="'. $linked .'" target="_new">');
+        $m->out('<a href="'. $linked .'" target="_blank">');
     }
     my $comp = "ShowCustomField". $cf->Type;
     $m->callback(

--- a/t/web/make-clicky.t
+++ b/t/web/make-clicky.t
@@ -18,7 +18,7 @@ diag "Trailing punctuation";
     for my $punc (qw( . ! ? ), ",") {
         is_string(
             make_clicky($m, "Refer to $url$punc  A following sentence."),
-            qq[Refer to <span class="clickylink"><a target="new" href="$url">$url</a></span>$punc  A following sentence.],
+            qq[Refer to <span class="clickylink"><a target="_blank" href="$url">$url</a></span>$punc  A following sentence.],
             "$punc not included in url",
         );
     }
@@ -31,7 +31,7 @@ diag "Punctuation as part of the url";
     RT::Interface::Web::EscapeHTML( \$escaped_url );
     is_string(
         make_clicky($m, "Refer to $url.  A following sentence."),
-        qq[Refer to <span class="clickylink"><a target="new" href="$escaped_url">$escaped_url</a></span>.  A following sentence.],
+        qq[Refer to <span class="clickylink"><a target="_blank" href="$escaped_url">$escaped_url</a></span>.  A following sentence.],
         "Punctuation in middle of URL",
     );
 }


### PR DESCRIPTION
Use something like "new" here would result in updating a browser tab/window
with the name "new" instead of opening a new browser tab/window.
Fix this by using the correct "_blank" value.