### PR TITLE
Use Content-ID when handling multipart message over REST.

### DIFF
--- a/lib/RT/Interface/REST.pm
+++ b/lib/RT/Interface/REST.pm
@@ -324,11 +324,17 @@ sub process_attachments {
         }
 
         my $info = $cgi->uploadInfo($fh);
+        # If Content-ID exists for attachment then we need multipart/related
+        # to be able to refer to this Content-Id in core of mime message
+        if($info->{'Content-ID'}) {
+            $entity->head->set('Content-Type', 'multipart/related');
+        }
         my $new_entity = $entity->attach(
             Path => $tmp_fn,
             Type => $info->{'Content-Type'} || guess_media_type($tmp_fn),
             Filename => $file,
             Disposition => $info->{'Content-Disposition'} || "attachment",
+            'Content-ID' => $info->{'Content-ID'},
         );
         $new_entity->bodyhandle->{'_dirty_hack_to_save_a_ref_tmp_fh'} = $tmp_fh;
         $i++;


### PR DESCRIPTION
Record Content-ID identifier that came over REST API.

This allows us to have multipart messages with one (or more) part
refering to other parts of message. Content-ID identifier is used for
reference.

Such message also needs multipart/related type (instead of default (in
rt) multipart/mixed. So if we detect Content-ID in any part of multipart
message we switch Content-Type to multipart/related.

Signed-off-by: Przemysław Plewa <przemyslaw.plewa@domena.pl>