### PR TITLE
pass SquelchMailTo to Ticket->Create

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -2142,6 +2142,7 @@ sub CreateTicket {
         Requestor       => $ARGS{'Requestors'},
         Cc              => $ARGS{'Cc'},
         AdminCc         => $ARGS{'AdminCc'},
+        SquelchMailTo   => $ARGS{'SquelchMailTo'},
         InitialPriority => $ARGS{'InitialPriority'},
         FinalPriority   => $ARGS{'FinalPriority'},
         TimeLeft        => $ARGS{'TimeLeft'},


### PR DESCRIPTION
1eba3f98e9fbd6795b3b4f108c5daba381fbf00a introduced creating tickets
with squelched recepients, but this was only done in Ticket->Create.

Actually the ticket create page passes his args to CreateTicket, which
furthur send only a subset of args to Ticket->Create.

Passing the SquelchMailTo to Ticket->Create makes it possible for custom
ticket create forms or extensions based on RT::Extension::FormTools to
squelch recepients on create.