### PR TITLE
Pass a scalar to File::Which::which rather than a list

### DIFF
--- a/lib/RT/Test.pm
+++ b/lib/RT/Test.pm
@@ -1718,9 +1718,9 @@ sub file_content {
 }
 
 sub find_executable {
-    my $self = shift;
+    my ( $self, $exe ) = @_;
 
-    return File::Which::which( @_ );
+    return File::Which::which( $exe );
 }
 
 sub diag {


### PR DESCRIPTION
File::Which 1.17 introduced a scalar prototype for the which() sub,
which broke the previous use of this in RT::Test. See
<https://github.com/plicease/File-Which/issues/6>.