### PR TITLE
Use parens to denote function call

### DIFF
--- a/lib/RT/Interface/Email.pm
+++ b/lib/RT/Interface/Email.pm
@@ -523,7 +523,7 @@ sub SendEmail {
         }
         my $content = $args{Entity}->stringify;
         $content =~ s/^(>*From )/>$1/mg;
-        print $fh "From $ENV{USER}\@localhost  ".localtime."\n";
+        print $fh "From $ENV{USER}\@localhost  ".localtime()."\n";
         print $fh $content, "\n";
         close $fh;
     } else {


### PR DESCRIPTION
Clears up this:
[Tue May 19 12:35:58 2015] [warning]: Warning: Use of "localtime" without parentheses is ambiguous at /apps/rt4/sbin/../lib/RT/Interface/Email.pm line 525. (/apps/rt4/sbin/../lib/RT/Interface/Email.pm:525)