### PR TITLE
fix titlebox title height for rudder

### DIFF
--- a/share/static/css/rudder/ticket.css
+++ b/share/static/css/rudder/ticket.css
@@ -36,7 +36,6 @@
 .ticket-info-attachments .titlebox-title  .left {
     padding-left: 2.25em;
     margin-left: 0;
-    padding-bottom: 4px;
     margin-bottom: 8px;
     -webkit-border-top-left-radius: 0.3em;
     -webkit-border-top-right-radius: 0.3em;


### PR DESCRIPTION
The correct padding-bottom of 0.25em is already set in rudder/boxes.css.

This fixes the wrong height of the titlebox title on some pages (e.g.
Ticket Basics) that could only be observed in Firefox.