### PR TITLE
Code warning fix

### DIFF
--- a/lib/RT/Interface/Email.pm
+++ b/lib/RT/Interface/Email.pm
@@ -523,7 +523,7 @@ sub SendEmail {
         }
         my $content = $args{Entity}->stringify;
         $content =~ s/^(>*From )/>$1/mg;
-        print $fh "From $ENV{USER}\@localhost  ".localtime."\n";
+        print $fh "From $ENV{USER}\@localhost  ".localtime()."\n";
         print $fh $content, "\n";
         close $fh;
     } else {


### PR DESCRIPTION
Warning: Use of "localtime" without parentheses is ambiguous at /opt/rt4/sbin/../lib/RT/Interface/Email.pm line 526.