### PR TITLE
consistent "now" value on ticket create

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -314,6 +314,10 @@ sub Create {
         unless defined $args{'Priority'};
 
     # Dates
+
+    my $Now = RT::Date->new( $self->CurrentUser );
+    $Now->SetToNow();
+
     #TODO we should see what sort of due date we're getting, rather +
     # than assuming it's in ISO format.
 
@@ -323,7 +327,7 @@ sub Create {
         $Due->Set( Format => 'ISO', Value => $args{'Due'} );
     }
     elsif ( my $due_in = $QueueObj->DefaultDueIn ) {
-        $Due->SetToNow;
+        $Due->Set( Format => 'ISO', Value => $Now->ISO );
         $Due->AddDays( $due_in );
     }
 
@@ -339,7 +343,7 @@ sub Create {
 
     # If the status is not an initial status, set the started date
     elsif ( !$cycle->IsInitial($args{'Status'}) ) {
-        $Started->SetToNow;
+        $Started->Set( Format => 'ISO', Value => $Now->ISO );
     }
 
     my $Resolved = RT::Date->new( $self->CurrentUser );
@@ -353,7 +357,7 @@ sub Create {
         $RT::Logger->debug( "Got a ". $args{'Status'}
             ."(inactive) ticket with undefined resolved date. Setting to now."
         );
-        $Resolved->SetToNow;
+        $Resolved->Set( Format => 'ISO', Value => $Now->ISO );
     }
 
     # Dealing with time fields
@@ -383,6 +387,7 @@ sub Create {
         TimeEstimated   => $args{'TimeEstimated'},
         TimeLeft        => $args{'TimeLeft'},
         Type            => $args{'Type'},
+        Created         => $Now->ISO,
         Starts          => $Starts->ISO,
         Started         => $Started->ISO,
         Resolved        => $Resolved->ISO,


### PR DESCRIPTION
Without this, creating a ticket with a open status, Started is set to
now in RT::Ticket->Create and Created is set to now in
RT::Record->Create, where the later method call can be a second later
(actually on the next second) than the former one. This results in
Started is one second before Created.

Avoid this by setting Created on RT::Ticket->Create.

Also use a consistent now value for other date values, if they are set
to now.

I'm not sure if we should also include a upgrade step to update Started and Resolved, if they are one second before Created.