### PR TITLE
Avoid warnings if users don't have sufficient rights on reminders

### DIFF
--- a/lib/RT/Transaction.pm
+++ b/lib/RT/Transaction.pm
@@ -1257,34 +1257,46 @@ sub _FormatUser {
         my $self = shift;
         my $ticket = RT::Ticket->new($self->CurrentUser);
         $ticket->Load($self->NewValue);
-        my $subject = [
-            \'<a href="', RT->Config->Get('WebPath'),
-            "/Ticket/Reminders.html?id=", $self->ObjectId,
-            "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
-        ];
-        return ("Reminder '[_1]' added", $subject); #loc()
+        if ( $ticket->CurrentUserHasRight('ShowTicket') ) {
+            my $subject = [
+                \'<a href="', RT->Config->Get('WebPath'),
+                "/Ticket/Reminders.html?id=", $self->ObjectId,
+                "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
+            ];
+            return ("Reminder '[_1]' added", $subject); #loc()
+        } else {
+            return ("Reminder added"); #loc()
+        }
     },
     OpenReminder => sub {
         my $self = shift;
         my $ticket = RT::Ticket->new($self->CurrentUser);
         $ticket->Load($self->NewValue);
-        my $subject = [
-            \'<a href="', RT->Config->Get('WebPath'),
-            "/Ticket/Reminders.html?id=", $self->ObjectId,
-            "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
-        ];
-        return ("Reminder '[_1]' reopened", $subject);  #loc()
+        if ( $ticket->CurrentUserHasRight('ShowTicket') ) {
+            my $subject = [
+                \'<a href="', RT->Config->Get('WebPath'),
+                "/Ticket/Reminders.html?id=", $self->ObjectId,
+                "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
+            ];
+            return ("Reminder '[_1]' reopened", $subject);  #loc()
+        } else {
+            return ("Reminder reopened");  #loc()
+        }
     },
     ResolveReminder => sub {
         my $self = shift;
         my $ticket = RT::Ticket->new($self->CurrentUser);
         $ticket->Load($self->NewValue);
-        my $subject = [
-            \'<a href="', RT->Config->Get('WebPath'),
-            "/Ticket/Reminders.html?id=", $self->ObjectId,
-            "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
-        ];
-        return ("Reminder '[_1]' completed", $subject); #loc()
+        if ( $ticket->CurrentUserHasRight('ShowTicket') ) {
+            my $subject = [
+                \'<a href="', RT->Config->Get('WebPath'),
+                "/Ticket/Reminders.html?id=", $self->ObjectId,
+                "#reminder-", $ticket->id, \'">', $ticket->Subject, \'</a>'
+            ];
+            return ("Reminder '[_1]' completed", $subject); #loc()
+        } else {
+            return ("Reminder completed"); #loc()
+        }
     }
 );
 

--- a/share/html/Elements/BulkLinks
+++ b/share/html/Elements/BulkLinks
@@ -106,7 +106,7 @@
 % if ( $hash{ReferredToBy} ) {
 % for my $link ( values %{$hash{ReferredToBy}} ) {
 % # Skip reminders
-% next if (UNIVERSAL::isa($link->BaseObj, 'RT::Ticket')  && $link->BaseObj->Type eq 'reminder');
+% next if (UNIVERSAL::isa($link->BaseObj, 'RT::Ticket')  && $link->BaseObj->__Value('Type') eq 'reminder');
       <input type="checkbox" class="checkbox" id="DeleteLink-<%$link->Base%>-<%$link->Type%>-" name="DeleteLink-<%$link->Base%>-<%$link->Type%>-" value="1" />
       <label for="DeleteLink-<%$link->Base%>-<%$link->Type%>-"><& /Elements/ShowLink, URI => $link->BaseURI &></label><br />
 % } }

--- a/share/html/Elements/EditLinks
+++ b/share/html/Elements/EditLinks
@@ -101,7 +101,7 @@
     <td class="value">
 % while (my $link = $Object->ReferredToBy->Next) {
 % # Skip reminders
-% next if (UNIVERSAL::isa($link->BaseObj, 'RT::Ticket')  && $link->BaseObj->Type eq 'reminder');
+% next if (UNIVERSAL::isa($link->BaseObj, 'RT::Ticket')  && $link->BaseObj->__Value('Type') eq 'reminder');
       <input type="checkbox" class="checkbox" id="DeleteLink-<%$link->Base%>-<%$link->Type%>-" name="DeleteLink-<%$link->Base%>-<%$link->Type%>-" value="1" />
       <label for="DeleteLink-<%$link->Base%>-<%$link->Type%>-"><& ShowLink, URI => $link->BaseURI &></label><br />
 % }

--- a/share/html/Elements/ShowLinksOfType
+++ b/share/html/Elements/ShowLinksOfType
@@ -91,7 +91,7 @@ while (my $link = $links->Next) {
     my $ToObj = $link->$ModeObj;
     if ($ToObj and $ToObj->isa('RT::Ticket')) {
         next if $Type eq "ReferredToBy"
-            and $ToObj->Type eq 'reminder';
+            and $ToObj->__Value('Type') eq 'reminder';
 
         if ( $ToObj->QueueObj->IsInactiveStatus( $ToObj->Status ) ) {
             push @inactive, $link;

--- a/share/html/Ticket/Create.html
+++ b/share/html/Ticket/Create.html
@@ -330,7 +330,7 @@ if ($CloneTicket) {
         return if $uri->IsLocal and
                 $uri->Object and
                 $uri->Object->isa('RT::Ticket') and
-                $uri->Object->Type eq 'reminder';
+                $uri->Object->__Value('Type') eq 'reminder';
 
         return $link->$local_method || $uri->URI;
     };

--- a/share/html/m/ticket/create
+++ b/share/html/m/ticket/create
@@ -98,7 +98,7 @@ if ($CloneTicket) {
         return if $uri->IsLocal and
                 $uri->Object and
                 $uri->Object->isa('RT::Ticket') and
-                $uri->Object->Type eq 'reminder';
+                $uri->Object->__Value('Type') eq 'reminder';
 
         return $link->$local_method || $uri->URI;
     };

--- a/share/html/m/ticket/show
+++ b/share/html/m/ticket/show
@@ -448,7 +448,7 @@ for my $link ( @{ $Ticket->DependsOn->ItemsArrayRef } ) {
     <div class="value">
     <ul>
 % while (my $Link = $Ticket->ReferredToBy->Next) {
-% next if (UNIVERSAL::isa($Link->BaseObj, 'RT::Ticket')  && $Link->BaseObj->Type eq 'reminder');
+% next if (UNIVERSAL::isa($Link->BaseObj, 'RT::Ticket')  && $Link->BaseObj->__Value('Type') eq 'reminder');
 <li><& /Elements/ShowLink, URI => $Link->BaseURI &></li>
 % }
 </ul>


### PR DESCRIPTION
Users must not have the same rights on tickets and their reminders
(e.g. if you use role based rights for ShowTicket and add a user to the
ticket role but not to the reminder role).

For Transaction->%_BriefDescriptions return a description without the
subject if the user don't have sufficient rights. This fixes warnings
like 'Use of uninitialized value in join or string at
/opt/rt4/sbin/../lib/RT/Transaction.pm line 827'.

For Links grab the Ticket->Type without ACL checks. We check here only
if it's a reminder to avoid display them as links. This fixes warnings
like 'Use of uninitialized value in string eq at
/opt/rtgit/share/html/Elements/ShowLinksOfType line 93'.