### PR TITLE
show the queue id if the user can't see the queue name

### DIFF
--- a/lib/RT/Transaction.pm
+++ b/lib/RT/Transaction.pm
@@ -1183,7 +1183,7 @@ sub _FormatUser {
             my $q2 = RT::Queue->new( $self->CurrentUser );
             $q2->Load( $self->NewValue );
             return ("[_1] changed from [_2] to [_3]",
-                    $self->loc($self->Field) , $q1->Name , $q2->Name);  #loc()
+                    $self->loc($self->Field), $q1->Name // '#'.$q1->id, $q2->Name // '#'.$q2->id); #loc()
         }
 
         # Write the date/time change at local time:


### PR DESCRIPTION
Show the queue id if the user doesn't have sufficient rights to see
the queue name.

If you move a ticket from queue q1 to q2 and the user have SeeQueue (and
ShowTicket) on q2 but not on q1, the descriptions shows previously
'Queue changed from to q2', which isn't very helpfull. Showing the queue
id gives the user a hint to tell the admin which queue he can't see.

This makes the queue display consistent with /Ticket/Elements/ShowQueue.

This also fixes the following warnings:
Use of uninitialized value $_[2] in join or string
Use of uninitialized value $_[3] in join or string