### PR TITLE
configurable attachment ordering method on web ui

### DIFF
--- a/share/html/Ticket/Elements/AddAttachments
+++ b/share/html/Ticket/Elements/AddAttachments
@@ -49,9 +49,11 @@
 <tr><td class="label"><&|/l&>Attached file</&>:</td>
 <td>
 <&|/l&>Check box to delete</&><br />
-% foreach my $attach_name ( sort keys %$attachments ) {
-<input type="checkbox" class="checkbox" name="DeleteAttach" value="<% $attach_name %>" id="DeleteAttach-<%$attach_name%>" />
-<label for="DeleteAttach-<%$attach_name%>"><% $attach_name %></label>
+%  foreach my $attach_id ( sort keys %{$attachments} ) {
+%  my %att_h = %{$attachments};
+%  my $attach_name = $att_h{$attach_id}{name};
+<input type="checkbox" class="checkbox" name="DeleteAttach" value="<% $attach_id %>" id="DeleteAttach-<%$attach_id%>" />
+<label for="DeleteAttach-<%$attach_id%>"><% $attach_name %></label>
 <br />
 % } # end of foreach
 </td>


### PR DESCRIPTION
From time to time we need to attach files to tickets in specified order. Currently RT forcedly orders attachments by name, regardless of the uploading order. To work this around one must rename their files an prepend a suffix to have a correct order (for that ticket). This is a tideious (and endless) work.

Width this patch if a configuration value "SortAttachmentsByUploadingOrder" is exist and the value is not zero, the uploading order of the attachments is preserved.