### PR TITLE
Skip tests which relate to old behaviour in t/mail/html-outgoing.t

### DIFF
--- a/t/mail/html-outgoing.t
+++ b/t/mail/html-outgoing.t
@@ -84,6 +84,9 @@ mail_ok {
 SKIP: {
     skip "Only fails on core HTMLFormatter", 9
         unless RT->Config->Get("HTMLFormatter") eq "core";
+    require HTML::FormatText::WithLinks::AndTables;
+    skip "Only fails with older verions of HTML::FormatText::WithLinks::AndTables", 9
+        unless $HTML::FormatText::WithLinks::AndTables::VERSION < 0.03;
     diag "Failing HTML -> Text conversion";
     warnings_like {
         my $body = '<table><tr><td><table><tr><td>Foo</td></tr></table></td></tr></table>';


### PR DESCRIPTION
Older versions of HTML-FormatText-WithLinks-AndTables were buggy
and this test assumes this, so skip if a non-buggy version is found.

Bug: https://issues.bestpractical.com/Ticket/Display.html?id=31191