### PR TITLE
don't index EmailRecord transaction attachments

### DIFF
--- a/lib/RT/Tickets.pm
+++ b/lib/RT/Tickets.pm
@@ -976,12 +976,19 @@ sub _TransContentLimit {
         }
     } else {
         $self->Limit(
+            ALIAS    => $txn_alias,
+            FIELD    => 'Type',
+            OPERATOR => 'NOT IN',
+            VALUE    => ['EmailRecord', 'CommentEmailRecord'],
+        );
+        $self->Limit(
             %rest,
-            ALIAS         => $self->{_sql_trattachalias},
-            FIELD         => $field,
-            OPERATOR      => $op,
-            VALUE         => $value,
-            CASESENSITIVE => 0,
+            ENTRYAGGREGATOR => 'AND',
+            ALIAS           => $self->{_sql_trattachalias},
+            FIELD           => $field,
+            OPERATOR        => $op,
+            VALUE           => $value,
+            CASESENSITIVE   => 0,
         );
     }
     if ( RT->Config->Get('DontSearchFileAttachments') ) {

--- a/sbin/rt-fulltext-indexer.in
+++ b/sbin/rt-fulltext-indexer.in
@@ -167,6 +167,18 @@ sub attachment_loop {
     {
         # Indexes all text/plain and text/html attachments
         my $attachments = RT::Attachments->new( RT->SystemUser );
+        my $txn_alias = $attachments->Join(
+            ALIAS1 => 'main',
+            FIELD1 => 'TransactionId',
+            TABLE2 => 'Transactions',
+            FIELD2 => 'id',
+        );
+        $attachments->Limit(
+            ALIAS    => $txn_alias,
+            FIELD    => 'Type',
+            OPERATOR => 'NOT IN',
+            VALUE    => ['EmailRecord', 'CommentEmailRecord'],
+        );
         $attachments->Limit(
             FIELD    => 'ContentType',
             OPERATOR => 'IN',

--- a/sbin/rt-fulltext-indexer.in
+++ b/sbin/rt-fulltext-indexer.in
@@ -217,7 +217,7 @@ sub process_bulk_insert {
             debug("Found attachment #". $a->id );
             my $text = $a->Content // "";
             HTML::Entities::decode_entities($text) if $a->ContentType eq "text/html";
-            push @insert, $text, $a->id;
+            push @insert, join("\n", $a->Subject // "", $text), $a->id;
             $found++;
         }
         return unless $found;
@@ -322,7 +322,7 @@ sub process_pg_update {
             my $text = $a->Content // "";
             HTML::Entities::decode_entities($text) if $a->ContentType eq "text/html";
 
-            push @insert, [$text, $a->id];
+            push @insert, [join("\n", $a->Subject // "", $text), $a->id];
         }
 
         # Try in one database transaction; if it fails, we roll it back


### PR DESCRIPTION
EmailRecord and CommentEmailRecord transaction attachments contains
redundant content as this attachments consist of the transaction
content (Create, Correspond or Comment) and the template text.

For example with the default RT configuration with queue AdminCcs, a
ticket create results in a Create transaction and two EmailRecord
transactions (one for the Requestor autoreply and one for the queue
AdminCcs).
So the valuable information in the create transaction attachment is
indexed three times.

Tests shows that not indexing the EmailRecord and CommentEmailRecord
transaction attachments drops first index time by 30%, indexed rows by
35%, index data file size by 27% and index index file size by 38%.

Test details (RT 4.2.12, MySQL 5.5.44, 1,534,314 plain/html
attachments):

before:
time /opt/rt4/sbin/rt-setup-fulltext-index --index-type mysql --table AttachmentsIndex
34m58.295s

mysql -BNe 'SELECT COUNT(*) FROM rt4.AttachmentsIndex'
1534314

du -h /var/lib/mysql/rt4/AttachmentsIndex.MY*
1.5G    /var/lib/mysql/rt4/AttachmentsIndex.MYD
782M    /var/lib/mysql/rt4/AttachmentsIndex.MYI

after:
time /opt/rt4/sbin/rt-setup-fulltext-index --index-type mysql --table AttachmentsIndex
24m4.712s

mysql -BNe 'SELECT COUNT(*) FROM rt4.AttachmentsIndex'
1000218

du -h /var/lib/mysql/rt4/AttachmentsIndex.MY*
1.1G    /var/lib/mysql/rt4/AttachmentsIndex.MYD
483M    /var/lib/mysql/rt4/AttachmentsIndex.MYI