### PR TITLE
use MiB instead of MB for attachment config options

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -393,7 +393,7 @@ read.
 
 =cut
 
-Set($MaxAttachmentSize, 10_000_000);  # 10M
+Set($MaxAttachmentSize, 10*1024*1024);  # 10MiB
 
 =item C<$TruncateLongAttachments>
 
@@ -2567,7 +2567,7 @@ Certain object types, like values for Binary (aka file upload) custom
 fields, are always put into external storage. However, for other
 object types, like images and text, there is a line in the sand where
 you want small objects in the database but large objects in external
-storage. By default, objects larger than 10 MB will be put into external
+storage. By default, objects larger than 10 MiB will be put into external
 storage. C<$ExternalStorageCutoffSize> adjusts that line in the sand.
 
 Note that changing this setting does not affect existing attachments, only
@@ -2575,7 +2575,7 @@ the new ones that C<sbin/rt-externalize-attachments> hasn't seen yet.
 
 =cut
 
-Set($ExternalStorageCutoffSize, 10_000_000);
+Set($ExternalStorageCutoffSize, 10*1024*1024);
 
 =item C<$ExternalStorageDirectLink>
 


### PR DESCRIPTION
Attachment size is shown in MiB in the web interface.
So it makes sense to also use MiB for attachment related config options.