### PR TITLE
avoid 'new ticket in' button width changes on focus

### DIFF
--- a/share/static/css/rudder/nav.css
+++ b/share/static/css/rudder/nav.css
@@ -147,7 +147,7 @@
     transition: width 0.25s ease-in-out;
 }
 
-#topactions input:focus {
+#topactions #simple-search input:focus {
     width: 16em;
     -webkit-transition: width 0.25s ease-in-out;
     -moz-transition: width 0.25s ease-in-out;


### PR DESCRIPTION
The intention of 3db1895 was to change the width of the search input,
not the width of the 'new ticket in' button.