### PR TITLE
fix pt_BR translation of "Open tickets"

### DIFF
--- a/share/po/pt_BR.po
+++ b/share/po/pt_BR.po
@@ -5731,7 +5731,7 @@ msgstr "Abrir tíquetes inativos"
 
 #: share/html/Elements/Tabs:963 share/html/SelfService/index.html:48
 msgid "Open tickets"
-msgstr "Abrir tíquetes"
+msgstr "Tíquetes abertos"
 
 #: etc/initialdata:103
 msgid "Open tickets on correspondence"


### PR DESCRIPTION
As the English string is ambiguous ("the tickets that are open" X "let's open some tickets now"), the original translator used the wrong meaning.