### PR TITLE
silence upgrade messages

### DIFF
--- a/etc/upgrade/4.3.1/content
+++ b/etc/upgrade/4.3.1/content
@@ -9,7 +9,11 @@ our @Initial = (
         $cfs->Limit( FIELD => 'EntryHint', VALUE => 'NULL', OPERATOR => 'IS' );
         while ( my $cf = $cfs->Next ) {
             my ($ret, $msg) = $cf->SetEntryHint($cf->FriendlyType);
-            RT->Logger->warning("Update Custom Field EntryHint for CF." . $cf->Id . " $msg");
+            if ($ret) {
+                RT->Logger->debug("Update Custom Field EntryHint for CF." . $cf->Id . " $msg");
+            } else {
+                RT->Logger->error("Failed to update Custom Field EntryHint for CF." . $cf->Id . " $msg");
+            }
         }
         return 1;
     },

--- a/etc/upgrade/4.3.11/content
+++ b/etc/upgrade/4.3.11/content
@@ -3,7 +3,7 @@ use warnings;
 
 our @Initial = (
     sub {
-        $RT::Logger->info("Going to migrate dashboard subscriptions");
+        $RT::Logger->debug("Going to migrate dashboard subscriptions");
 
         my $attrs = RT::Attributes->new( RT->SystemUser );
         $attrs->Limit( FIELD => 'ObjectType', VALUE => 'RT::User' );


### PR DESCRIPTION
For 4.3.1 it don't makes sense to display a message for each custom
field during the upgrade (unless you turn on debug logging).

For 4.3.11 this message should only be relevant if you want to debug the
upgrade, but not for the normal user.