### PR TITLE
rewrite Windows newlines

### DIFF
--- a/lib/RT/EmailParser.pm
+++ b/lib/RT/EmailParser.pm
@@ -642,7 +642,7 @@ sub RescueOutlook {
 
         # use the unencoded string
         my $content = $text_part->bodyhandle->as_string;
-        if ( $content =~ s/\n\n/\n/g ) {
+        if ( $content =~ s/\r?\n\r?\n/\n/g ) {
 
             # Outlook puts a space on extra newlines, remove it
             $content =~ s/\ +$//mg;


### PR DESCRIPTION
Rewrite Windows newlines (CRLF), as seen in recent Outlook 2010.
As the original implementation from 58dfb2b seem to work with LF, making
the CR optional.
