### PR TITLE
fix accented queue name (en)coding if not utf8

### DIFF
--- a/bin/rt-mailgate.in
+++ b/bin/rt-mailgate.in
@@ -56,6 +56,8 @@ use strict;
 use warnings;
 
 use Getopt::Long;
+use utf8;
+no utf8;
 
 my $opts = { };
 GetOptions( $opts,   "queue=s", "action=s", "url=s",
@@ -63,6 +65,7 @@ GetOptions( $opts,   "queue=s", "action=s", "url=s",
             "timeout=i", "verify-ssl!", "ca-file=s",
           );
 
+if ( !utf8::is_utf8( $opts->{"queue"} ) ) { utf8::decode( $opts->{"queue"} ); }
 my $gateway = RT::Client::MailGateway->new();
 
 $gateway->run($opts);


### PR DESCRIPTION
this little fix corrects queue name (en)coding if it contains accented but not necessary utf8 character(s).

The queue name is 'UKK üzemeltetés'.
The line in the (utf8 encoded) aliases file is
ukkuzemeltetes:         "|/usr/bin/rt-mailgate --ca-file /etc/ssl/certs/mithrandir.ca.crt --queue 'UKK üzemeltetés' --action correspond --url https://rt.mithrandir.hu/"

Without the fix, we got the below error is syslog, and the mail waits in the mail queue with a temporary error.

Jan 12 10:44:23 mail RT: [23963] Could not record email: RT couldn't find the queue: UKK Ã¼zemeltetÃ©s
Jan 12 10:44:23 mail postfix/local[25018]: 0BF9B1060: to=<ukkuzemeltetes@mithrandir.hu>, relay=local, delay=0.35, delays=0.01/0.01/0/0.33, dsn=4
.3.0, status=deferred (temporary failure. Command output: RT server error.  The RT server which handled your email did not behave as expected. I
t said:  temporary failure - RT couldn't find the queue: UKK __zemeltet__s  )

The fix should apply to the upcoming 4.4 too, as the file appears to be the same.