### PR TITLE
new config option MaxInlineImage

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -1829,6 +1829,17 @@ their preferences.
 
 Set($MaxInlineBody, 12000);
 
+=item C<$MaxInlineImage>
+
+C<$MaxInlineImage> is the maximum image size that we want to see
+inline when viewing a transaction. RT will inline any image if the
+value is undefined or 0. This option can be overridden by users in
+their preferences.
+
+=cut
+
+Set($MaxInlineImage, 0);
+
 =item C<$ShowTransactionImages>
 
 By default, RT shows images attached to incoming (and outgoing) ticket

--- a/lib/RT/Config.pm
+++ b/lib/RT/Config.pm
@@ -370,10 +370,21 @@ our %META;
             "Length in characters; Use '0' to show all messages inline, regardless of length" #loc
         },
     },
+    MaxInlineImage => {
+        Section         => 'Ticket display',              #loc
+        Overridable     => 1,
+        SortOrder       => 2,
+        Widget          => '/Widgets/Form/Integer',
+        WidgetArguments => {
+            Description => 'Maximum inline image size',    #loc
+            Hints =>
+            "Length in bytes; Use '0' to show all images inline, regardless of their size" #loc
+        },
+    },
     OldestTransactionsFirst => {
         Section         => 'Ticket display',
         Overridable     => 1,
-        SortOrder       => 2,
+        SortOrder       => 3,
         Widget          => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => 'Show oldest history first',    #loc
@@ -382,7 +393,7 @@ our %META;
     ShowHistory => {
         Section         => 'Ticket display',
         Overridable     => 1,
-        SortOrder       => 3,
+        SortOrder       => 4,
         Widget          => '/Widgets/Form/Select',
         WidgetArguments => {
             Description => 'Show history',                #loc
@@ -397,7 +408,7 @@ our %META;
     ShowUnreadMessageNotifications => { 
         Section         => 'Ticket display',
         Overridable     => 1,
-        SortOrder       => 4,
+        SortOrder       => 5,
         Widget          => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => 'Notify me of unread messages',    #loc
@@ -424,7 +435,7 @@ our %META;
     PlainTextMono => {
         Section         => 'Ticket display',
         Overridable     => 1,
-        SortOrder       => 5,
+        SortOrder       => 6,
         Widget          => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => 'Display plain-text attachments in fixed-width font', #loc
@@ -434,7 +445,7 @@ our %META;
     MoreAboutRequestorTicketList => {
         Section         => 'Ticket display',                       #loc
         Overridable     => 1,
-        SortOrder       => 6,
+        SortOrder       => 7,
         Widget          => '/Widgets/Form/Select',
         WidgetArguments => {
             Description => 'What tickets to display in the "More about requestor" box',                #loc
@@ -450,7 +461,7 @@ our %META;
     SimplifiedRecipients => {
         Section         => 'Ticket display',                       #loc
         Overridable     => 1,
-        SortOrder       => 7,
+        SortOrder       => 8,
         Widget          => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => "Show simplified recipient list on ticket update",                #loc
@@ -459,7 +470,7 @@ our %META;
     DisplayTicketAfterQuickCreate => {
         Section         => 'Ticket display',
         Overridable     => 1,
-        SortOrder       => 8,
+        SortOrder       => 9,
         Widget          => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => 'Display ticket after "Quick Create"', #loc
@@ -468,7 +479,7 @@ our %META;
     QuoteFolding => {
         Section => 'Ticket display',
         Overridable => 1,
-        SortOrder => 9,
+        SortOrder => 10,
         Widget => '/Widgets/Form/Boolean',
         WidgetArguments => {
             Description => 'Enable quote folding?' # loc

--- a/share/html/Elements/ShowTransactionAttachments
+++ b/share/html/Elements/ShowTransactionAttachments
@@ -260,6 +260,7 @@ my $render_attachment = sub {
 
     # if it's an image, show it as an image
     elsif ( $content_type =~ m{^image/} ) {
+        my $max_size = RT->Config->Get( 'MaxInlineImage', $session{'CurrentUser'} );
         if (not RT->Config->Get('ShowTransactionImages')) {
             $m->out('<p><i>'. loc( 'Image not shown because display is disabled in system configuration.' ) .'</i></p>');
             return;
@@ -270,6 +271,10 @@ my $render_attachment = sub {
         }
         elsif ( $disposition ne 'inline' ) {
             $m->out('<p>'. loc( 'Image not shown because sender requested not to inline it.' ) .'</p>');
+            return;
+        }
+        elsif ( $max_size && $message->ContentLength > $max_size ) {
+            $m->out('<p>'. loc( 'Image not shown because it is too large.' ) .'</p>');
             return;
         }
 


### PR DESCRIPTION
Similar to MaxInlineBody, this lets users limit the maximum size of
inline displayed images.