### PR TITLE
pass %ARGS to ShowHistoryPage

### DIFF
--- a/share/html/Elements/ShowHistory
+++ b/share/html/Elements/ShowHistory
@@ -55,6 +55,7 @@
 % $m->callback( %ARGS, Object => $Object, CallbackName => 'BeforeTransactions' );
 
 <& /Elements/ShowHistoryPage,
+    %ARGS,
     Object            => $Object,
     Transactions      => $Object->SortedTransactions,
     ShowHeaders       => $ARGS{'ShowHeaders'},


### PR DESCRIPTION
Without this, ShowHistoryPage sets DisplayPath always to 'Display.html',
instead of the value passed through %ARGS.
This results in clicking the transaction links on the History.html pages
(ticket, user) redirects you to Display.html instead of History.html.

This fixes a regression that was introduced by 1456980.