### PR TITLE
Added merged ticket IDs to ticket details in REST API.

### DIFF
--- a/share/html/REST/1.0/Forms/ticket/default
+++ b/share/html/REST/1.0/Forms/ticket/default
@@ -236,6 +236,8 @@ if (!keys(%data)) {
     my ($time, $key, $val, @data);
 
     push @data, [ id    => "ticket/".$ticket->Id   ];
+    push @data, [ Merged => join(", ", $ticket->Merged) ]
+        if $ticket->Merged;
     push @data, [ Queue => $ticket->QueueObj->Name ]
         if (!%$fields || exists $fields->{lc 'Queue'});
     push @data, [ Owner => $ticket->OwnerObj->Name ]


### PR DESCRIPTION
We are writing a synchronization job between RT and other systems. We use queries to find tickets updated/created since last sync time.
Then, when querying tickets using their IDs, merged tickets will instead return the "new" ticket information.  We must be able to detect merged tickets and we cannot afford to query information about all existing open tickets at all time to discover merged tickets and merge them in the other systems.  
We could query the merged ticket history but it seems a bit too expansive and exhaustive only to detect merge operations.
Exposing the list of ticket IDs merged into a given ticket gives the same information more efficiently.