### PR TITLE
force .load to POST instead of GET

### DIFF
--- a/share/html/Ticket/Update.html
+++ b/share/html/Ticket/Update.html
@@ -222,7 +222,7 @@ jQuery( function() {
            }
        );
        jQuery('#previewscrips div.titlebox-content').load( '<% RT->Config->Get('WebPath')%>/Helpers/PreviewScrips',
-           jQuery('form[name=TicketUpdate]').serialize(),
+           jQuery('form[name=TicketUpdate]').serializeObject(),
            function() {
                var txn_send_field = jQuery("#previewscrips input[name=TxnSendMailTo]");
                txn_send_field.change( syncCheckboxes );

--- a/share/static/js/util.js
+++ b/share/static/js/util.js
@@ -565,3 +565,19 @@ function scrollToJQueryObject(obj) {
     }
 }
 
+// https://css-tricks.com/snippets/jquery/serialize-form-to-json/
+jQuery.fn.serializeObject = function() {
+   var o = {};
+   var a = this.serializeArray();
+   jQuery.each(a, function() {
+       if (o[this.name]) {
+           if (!o[this.name].push) {
+               o[this.name] = [o[this.name]];
+           }
+           o[this.name].push(this.value || '');
+       } else {
+           o[this.name] = this.value || '';
+       }
+   });
+   return o;
+};


### PR DESCRIPTION
AJAXifying the preview scrips with .load() via .serialize() does a GET
request with the Display.html form, and the query string can end up too
long for the server to accept it.

This commit adds a helper to serialize the form as an object instead of
query string, which tells .load to POST instead of GET. It looks like
theres no built in jQuery interface to serialize a form as an object so
the helper is needed.

Fixes issues#31874