### PR TITLE
Added ability to perform searches including deleted tickets.

### DIFF
--- a/share/html/REST/1.0/search/dhandler
+++ b/share/html/REST/1.0/search/dhandler
@@ -52,6 +52,7 @@ $query
 $format => undef
 $orderby => undef
 $fields => undef
+$include_deleted => undef
 </%ARGS>
 <%INIT>
 my $type = $m->dhandler_arg;
@@ -116,6 +117,10 @@ if ( $type =~ /^(ticket|queue|user|group)$/i ) {
 
     if ( defined $query && length $query ) {
         if ( $type eq 'ticket' ) {
+            if ($include_deleted) {
+                 $objects->{'allow_deleted_search'} = 1
+            }
+
             my ( $n, $s );
             eval { ( $n, $s ) = $objects->FromSQL($query); };
             if ( $@ || $n == 0 ) {


### PR DESCRIPTION
We are writing a synchronization job between RT and other systems. We use queries to find tickets updated/created since last sync time.
Unfortunately, there is no way using the search REST API to query for recently deleted tickets. Polling status for each previously synced ticket is out of the question since it is inefficient and volume would produce too much server load.

This adds a new query parameter "include_deleted" to enable search support for deleted tickets only.

I didn't know the search use-cases for other entity types (ie users, queues) and if you provide pointers I can also make my patch support them, although it seems there are existing "LimitToDisabled/Enabled" calls for those entity types.
