### PR TITLE
ignore From_ line in header

### DIFF
--- a/lib/RT/Attachment.pm
+++ b/lib/RT/Attachment.pm
@@ -769,6 +769,7 @@ sub _SplitHeaders {
     # continuations and rely on this bogus split pattern, however, so it is
     # left as-is for now.
     for (split(/\n(?=\w|\z)/,$headers)) {
+        next if /^>?From /;
         push @headers, $_;
 
     }


### PR DESCRIPTION
MDA (Postfix, procmail) add a From_ line to the header like this:

From cloos@netcologne.de  Tue May 10 14:55:10 2016

If we don't ignore this line ContentAsMIME split this line by the first
':' and then reassembles the line to a header like this:

From cloos@netcologne.de  Tue May 10 14: 55:10 2016

This isn't RFC 5322 conform, because header names aren't allowed to
include spaces.

MIME::Parser up to 5.428 already ignored the From_ line, but this was
removed in 5.500.
