### PR TITLE
fix fetching user for MailCommand mbox

### DIFF
--- a/lib/RT/Interface/Email.pm
+++ b/lib/RT/Interface/Email.pm
@@ -523,7 +523,8 @@ sub SendEmail {
         }
         my $content = $args{Entity}->stringify;
         $content =~ s/^(>*From )/>$1/mg;
-        print $fh "From $ENV{USER}\@localhost  ".localtime()."\n";
+        my $user = getpwuid($<);
+        print $fh "From $user\@localhost  ".localtime()."\n";
         print $fh $content, "\n";
         close $fh;
     } else {


### PR DESCRIPTION
With fastcgi deploys, %ENV doesn't have a USER key.
Use getpwuid here to fetch the user.

This fixes warnings:
Use of uninitialized value $ENV{"USER"} in concatenation (.) or string