### PR TITLE
Skip the password change form with external auth.

### DIFF
--- a/share/html/SelfService/Prefs.html
+++ b/share/html/SelfService/Prefs.html
@@ -68,10 +68,12 @@
 </td>
 <td valign="top">
 <&| /Widgets/TitleBox, title => loc('Change password')  &>
+% if ( $user->__Value('Password') ne '*NO-PASSWORD*' ) {
 <& /Elements/EditPassword,
     User => $user,
     Name => [qw(CurrentPass NewPass1 NewPass2)],
 &>
+% }
 </&>
 
 </td></tr></table>


### PR DESCRIPTION
This adds the same *NO-PASSWORD* check that the internal Prefs/AboutMe.html page has. For RT installs that are using $WebRemoteUserAuth or $ExternalAuthPriority, there is no internal RT password and the presence of the password change form is confusing to SelfService users.