### PR TITLE
add a new $OverrideMailPrecedence config option

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -598,6 +598,23 @@ Precedence header, it will be preserved.
 
 Set($DefaultMailPrecedence, "bulk");
 
+=item C<$OverrideMailPrecedence>
+
+C<$OverrideMailPrecedence> is used for overwriting the C<$DefaultMailPrecedence>
+value for a queue.
+
+The option is a hash reference of queue id/name to precedence. If you set the
+precedence to C<undef>, a Precedence header will not be added to the mail.
+
+This option only works if C<$DefaultMailPrecedence> is enabled.
+
+=cut
+
+Set($OverrideMailPrecedence, {
+#    'Queue 1' => "list",
+#    'Queue 2' => undef,
+});
+
 =item C<$DefaultErrorMailPrecedence>
 
 C<$DefaultErrorMailPrecedence> is used to control the default

--- a/lib/RT/Interface/Email.pm
+++ b/lib/RT/Interface/Email.pm
@@ -415,7 +415,18 @@ sub SendEmail {
     if (my $precedence = RT->Config->Get('DefaultMailPrecedence')
         and !$args{'Entity'}->head->get("Precedence")
     ) {
-        $args{'Entity'}->head->replace( 'Precedence', Encode::encode("UTF-8",$precedence) );
+        if ($TicketObj) {
+            my $Overrides = RT->Config->Get('OverrideMailPrecedence') || {};
+            my $Queue = $TicketObj->QueueObj;
+
+            $precedence = $Overrides->{$Queue->id}
+                if exists $Overrides->{$Queue->id};
+            $precedence = $Overrides->{$Queue->Name}
+                if exists $Overrides->{$Queue->Name};
+        }
+
+        $args{'Entity'}->head->replace( 'Precedence', Encode::encode("UTF-8",$precedence) )
+            if $precedence;
     }
 
     if ( $TransactionObj && !$TicketObj

--- a/t/mail/precedence-outgoing.t
+++ b/t/mail/precedence-outgoing.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+
+use RT::Test tests => undef;
+use RT::Test::Email;
+use Test::Warn;
+
+RT->Config->Set( DefaultMailPrecedence => "bulk" );
+RT->Config->Set( OverrideMailPrecedence => {
+    "test_list" => "list",
+    "test_undef" => undef,
+});
+
+{
+    my $queue = RT::Test->load_or_create_queue( Name => 'General' );
+    ok $queue && $queue->id, 'loaded or created queue General';
+
+    my $ticket = RT::Ticket->new( RT::CurrentUser->new( RT->SystemUser ) );
+    mail_ok {
+        my ($status, undef, $msg) = $ticket->Create(
+            Queue     => $queue->id,
+            Subject   => 'test bulk',
+            Requestor => 'root@localhost',
+        );
+        ok $status, "created ticket 'test bulk'";
+    } { Precedence => "bulk" };
+}
+
+{
+    my $queue = RT::Test->load_or_create_queue( Name => "test_list" );
+    ok $queue && $queue->id, 'loaded or created queue test_list';
+
+    my $ticket = RT::Ticket->new( RT::CurrentUser->new( RT->SystemUser ) );
+    mail_ok {
+        my ($status, undef, $msg) = $ticket->Create(
+            Queue     => $queue->id,
+            Subject   => 'test list',
+            Requestor => 'root@localhost',
+        );
+        ok $status, "created ticket 'test list'";
+    } { Precedence => "list" };
+}
+
+{
+    my $queue = RT::Test->load_or_create_queue( Name => "test_undef" );
+    ok $queue && $queue->id, 'loaded or created queue test_undef';
+
+    my $ticket = RT::Ticket->new( RT::CurrentUser->new( RT->SystemUser ) );
+    mail_ok {
+        my ($status, undef, $msg) = $ticket->Create(
+            Queue     => $queue->id,
+            Subject   => 'test undef',
+            Requestor => 'root@localhost',
+        );
+        ok $status, "created ticket 'test undef'";
+    } { Precedence => "" };
+}
+
+done_testing;


### PR DESCRIPTION
While you can set a specific Precedene header for a queue by a queue
template, as described in $DefaultMailPrecedence, you can't supress a
Precedence header this way.
Testing shows, that sending an mail with an empty Precedence header, the
responder don't send automatic responses, like vacation messages.