### PR TITLE
Fixes relating to gpg 2.1 (in)compatibility

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -2525,7 +2525,8 @@ be found by running the command `perldoc L<RT::Crypt::GnuPG>` (or
 Set C<Enable> to 0 or 1 to disable or enable GnuPG interfaces
 for encrypting and signing outgoing messages.
 
-Set C<GnuPG> to the name or path of the gpg binary to use.
+Set C<GnuPG> to the name or path of the gpg binary to use to override
+the GnuPG::Interface default.
 
 Set C<Passphrase> to a scalar (to use for all keys), an anonymous
 function, or a hash (to look up by address).  If the hash is used, the
@@ -2538,7 +2539,6 @@ signatures instead of 'RFC' (GPG/MIME: RFC3156 and RFC1847) format.
 
 Set(%GnuPG,
     Enable                 => @RT_GPG@,
-    GnuPG                  => 'gpg',
     Passphrase             => undef,
     OutgoingMessagesFormat => "RFC", # Inline
 );

--- a/lib/RT/Config.pm
+++ b/lib/RT/Config.pm
@@ -725,8 +725,6 @@ our %META;
                 if (not RT::Crypt->LoadImplementation($proto)) {
                     $RT::Logger->error("You enabled $proto, but we couldn't load module RT::Crypt::$proto");
                     $opt->{'Enable'} = 0;
-                } elsif (not RT::Crypt->LoadImplementation($proto)->Probe) {
-                    $opt->{'Enable'} = 0;
                 } elsif ($META{$proto}{'PostLoadCheck'}) {
                     $META{$proto}{'PostLoadCheck'}->( $self, $self->Get( $proto ) );
                 }

--- a/lib/RT/Crypt/GnuPG.pm
+++ b/lib/RT/Crypt/GnuPG.pm
@@ -345,7 +345,7 @@ sub CallGnuPG {
         %{ $args{Options} || {} },
     );
     my $gnupg = GnuPG::Interface->new;
-    $gnupg->call( $self->GnuPGPath );
+    $gnupg->call( $self->GnuPGPath ) if defined $self->GnuPGPath;
     $gnupg->options->hash_init(
         _PrepareGnuPGOptions( %opt ),
     );
@@ -1828,6 +1828,8 @@ sub GnuPGPath {
     return $cache;
 }
 
+# XXX This is no longer called, since it relies on the path to gpg
+# being known, which isn't necessary
 sub Probe {
     my $self = shift;
     my $gnupg = GnuPG::Interface->new;


### PR DESCRIPTION
RT doesn't work with gpg 2.1 at the moment (mostly because GnuPG::Interface doesn't. This patch series fixed this indirectly in Debian to not hardcode the path to gpg by default, so that the default configured in GnuPG::Interface is used instead.
