### PR TITLE
Fix RT::I18N and the test suite to work without cwd in @INC

### DIFF
--- a/lib/RT/I18N.pm
+++ b/lib/RT/I18N.pm
@@ -56,6 +56,7 @@ package RT::I18N;
 
 use strict;
 use warnings;
+use Cwd ();
 
 
 use Locale::Maketext 1.04;
@@ -97,10 +98,10 @@ sub Init {
     @lang = ('*') unless @lang;
 
     # load default functions
-    require substr(__FILE__, 0, -3) . '/i_default.pm';
+    require substr(Cwd::abs_path(__FILE__), 0, -3) . '/i_default.pm';
 
     # Load language-specific functions
-    foreach my $file ( File::Glob::bsd_glob(substr(__FILE__, 0, -3) . "/*.pm") ) {
+    foreach my $file ( File::Glob::bsd_glob(substr(Cwd::abs_path(__FILE__), 0, -3) . "/*.pm") ) {
         my ($lang) = ($file =~ /([^\\\/]+?)\.pm$/);
         next unless grep $_ eq '*' || $_ eq $lang, @lang;
         require $file;

--- a/t/lifecycles/basics.t
+++ b/t/lifecycles/basics.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-BEGIN {require  't/lifecycles/utils.pl'};
+BEGIN {require  './t/lifecycles/utils.pl'};
 
 my $general = RT::Test->load_or_create_queue(
     Name => 'General',

--- a/t/lifecycles/dates.t
+++ b/t/lifecycles/dates.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-BEGIN {require 't/lifecycles/utils.pl'};
+BEGIN {require './t/lifecycles/utils.pl'};
 
 my $general = RT::Test->load_or_create_queue(
     Name => 'General',

--- a/t/lifecycles/moving.t
+++ b/t/lifecycles/moving.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-BEGIN {require 't/lifecycles/utils.pl'};
+BEGIN {require './t/lifecycles/utils.pl'};
 
 my $general = RT::Test->load_or_create_queue(
     Name => 'General',

--- a/t/lifecycles/types.t
+++ b/t/lifecycles/types.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-BEGIN {require  't/lifecycles/utils.pl'};
+BEGIN {require  './t/lifecycles/utils.pl'};
 
 is_deeply( [ RT::Lifecycle->ListAll ], [qw/ approvals default delivery /],
        "Get the list of all lifecycles (implicitly for for tickets)");

--- a/t/lifecycles/unresolved-deps.t
+++ b/t/lifecycles/unresolved-deps.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-BEGIN {require  't/lifecycles/utils.pl'};
+BEGIN {require  './t/lifecycles/utils.pl'};
 
 my $general = RT::Test->load_or_create_queue(
     Name => 'General',


### PR DESCRIPTION
This change to remove '.' from @INC has been made in Debian recently, and is expected to be made upstream for perl 5.26; see https://rt.perl.org/Ticket/Display.html?id=127810