### PR TITLE
Fix problematic case-sensitivity in ExternalAuth::DBI.

### DIFF
--- a/lib/RT/Authen/ExternalAuth/DBI.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI.pm
@@ -222,13 +222,13 @@ sub GetAuth {
     my $dbh = _GetBoundDBIObj($config);
     return 0 unless $dbh;
 
-    my $results_hashref = $dbh->selectall_hashref($query,$db_u_field,{},@params);
+    my $results = $dbh->selectall_arrayref($query,{Slice=>{}},@params);
     $dbh->disconnect();
 
-    my $num_users_returned = scalar keys %$results_hashref;
+    my $num_users_returned = scalar @$results;
     if($num_users_returned != 1) { # FAIL
         # FAIL because more than one user returned. Users MUST be unique!
-        if ((scalar keys %$results_hashref) > 1) {
+        if ($num_users_returned > 1) {
             $RT::Logger->info(  $service,
                                 "AUTH FAILED",
                                 $username,
@@ -236,7 +236,7 @@ sub GetAuth {
         }
 
         # FAIL because no users returned. Users MUST exist!
-        if ((scalar keys %$results_hashref) < 1) {
+        if ($num_users_returned < 1) {
             $RT::Logger->info(  $service,
                                 "AUTH FAILED",
                                 $username,
@@ -248,7 +248,7 @@ sub GetAuth {
     }
 
     # Get the user's password from the database query result
-    my $pass_from_db = $results_hashref->{$username}->{$db_p_field};
+    my $pass_from_db = $results->[0]->{$db_p_field};
 
     if ( $db_p_check ) {
         unless ( ref $db_p_check eq 'CODE' ) {
@@ -381,14 +381,15 @@ sub CanonicalizeUserInfo {
     # Uncomment this to trace basic DBI throughput in a log
     # DBI->trace(1,'/tmp/dbi.log');
     my $dbh = _GetBoundDBIObj($config);
-    my $results_hashref = $dbh->selectall_hashref($query,$key,{},@bind_params);
+    my $results = $dbh->selectall_arrayref($query,{Slice=>{}},@bind_params);
     $dbh->disconnect();
 
-    if ((scalar keys %$results_hashref) != 1) {
+    my $num_users_returned = scalar @$results;
+    if ($num_users_returned != 1) {
         # If returned users <> 1, we have no single unique user, so prepare to die
         my $death_msg;
 
-            if ((scalar keys %$results_hashref) == 0) {
+            if ($num_users_returned == 0) {
             # If no user...
                 $death_msg = "No User Found in External Database!";
         } else {
@@ -411,7 +412,7 @@ sub CanonicalizeUserInfo {
 
     # We haven't dropped out, so DB search must have succeeded with
     # exactly 1 result. Get the result and set $found to 1
-    my $result = $results_hashref->{$value};
+    my $result = $results->[0];
 
     # Use the result to populate %params for every key we're given in the config
     foreach my $key (keys(%{$config->{'attr_map'}})) {
@@ -437,11 +438,10 @@ sub UserExists {
 
     # Get DBI Object, do the query, disconnect
     my $dbh = _GetBoundDBIObj($config);
-    my $results_hashref = $dbh->selectall_hashref($query,$u_field,{},@bind_params);
+    my $results = $dbh->selectall_arrayref($query,{},@bind_params);
     $dbh->disconnect();
 
-    my $num_of_results = scalar keys %$results_hashref;
-
+    my $num_of_results = scalar @$results;
     if ($num_of_results > 1) {
         # If more than one result returned, die because we the username field should be unique!
         $RT::Logger->debug( "Disable Check Failed :: (",
@@ -497,11 +497,10 @@ sub UserDisabled {
 
     # Get DBI Object, do the query, disconnect
     my $dbh = _GetBoundDBIObj($config);
-    my $results_hashref = $dbh->selectall_hashref($query,$u_field,{},@bind_params);
+    my $results = $dbh->selectall_arrayref($query,{Slice=>{}},@bind_params);
     $dbh->disconnect();
 
-    my $num_of_results = scalar keys %$results_hashref;
-
+    my $num_of_results = scalar @$results;
     if ($num_of_results > 1) {
         # If more than one result returned, die because we the username field should be unique!
         $RT::Logger->debug( "Disable Check Failed :: (",
@@ -524,7 +523,7 @@ sub UserDisabled {
         # otherwise all should be well
 
         # $user_db_disable_value = The value for "disabled" returned from the DB
-        my $user_db_disable_value = $results_hashref->{$username}->{$disable_field};
+        my $user_db_disable_value = $results->[0]->{$disable_field};
 
         # For each of the values in the (list of values that we consider to mean the user is disabled)..
         foreach my $disable_value (@{$disable_values_list}){

--- a/t/externalauth/sqlite.t
+++ b/t/externalauth/sqlite.t
@@ -3,16 +3,12 @@ use warnings;
 
 use RT::Test tests => undef;
 
-eval { require RT::Authen::ExternalAuth; require Net::LDAP::Server::Test; 1; } or do {
-    plan skip_all => 'Unable to test without Net::LDAP and Net::LDAP::Server::Test';
-};
-
 use DBI;
 use File::Temp;
 use Digest::MD5;
 use File::Spec;
 
-eval { require DBD::SQLite; } or do {
+eval { require RT::Authen::ExternalAuth; require DBD::SQLite; } or do {
     plan skip_all => 'Unable to test without DBD::SQLite';
 };
 
@@ -23,14 +19,19 @@ my $dbh = DBI->connect("dbi:SQLite:$dbname");
 my $password = Digest::MD5::md5_hex('password');
 my $schema = <<"EOF";
 CREATE TABLE users (
-  username varchar(200) NOT NULL,
+  username varchar(200) NOT NULL COLLATE NOCASE,
   password varchar(40) NULL,
-  email varchar(16) NULL
+  email varchar(16) NULL COLLATE NOCASE,
+  disabled int
 );
 EOF
 $dbh->do( $schema );
-$dbh->do(
-"INSERT INTO $table VALUES ( 'testuser', '$password', 'testuser\@invalid.tld')"
+$dbh->do( <<"EOF"
+INSERT INTO $table VALUES
+    ( 'testuser', '$password', 'testuser\@invalid.tld', 0),
+    ( 'testCASE', '$password', 'testcase\@invalid.tld', 0),
+    ( 'testmail', '$password', 'testMAIL\@invalid.tld', 0)
+EOF
 );
 
 RT->Config->Set( ExternalAuthPriority        => ['My_SQLite'] );
@@ -48,7 +49,8 @@ RT->Config->Set(
             'p_field'         => 'password',
             'p_enc_pkg'       => 'Digest::MD5',
             'p_enc_sub'       => 'md5_hex',
-            'attr_match_list' => ['Name'],
+            'd_field'         => 'disabled',
+            'attr_match_list' => ['Name', 'EmailAddress'],
             'attr_map'        => {
                 'Name'           => 'username',
                 'EmailAddress'   => 'email',
@@ -65,6 +67,9 @@ diag "test uri login";
     ok( !$m->login( 'fakeuser', 'password' ), 'not logged in with fake user' );
     ok( !$m->login( 'testuser', 'wrongpassword' ), 'not logged in with wrong password' );
     ok( $m->login( 'testuser', 'password' ), 'logged in' );
+
+    ok( $m->logout, 'logged out' );
+    ok( $m->login( 'testcase', 'password' ), 'logged in with case mismatch' );
 }
 
 diag "test user creation";
@@ -73,6 +78,22 @@ my $testuser = RT::User->new($RT::SystemUser);
 my ($ok,$msg) = $testuser->Load( 'testuser' );
 ok($ok,$msg);
 is($testuser->EmailAddress,'testuser@invalid.tld');
+}
+
+diag "test user creation with case mismatch";
+{
+    my $testuser = RT::User->new($RT::SystemUser);
+    my ($ok, $msg) = $testuser->Load( 'testCASE' );
+    ok( $ok, "create user: $msg" );
+    is( $testuser->EmailAddress, 'testcase@invalid.tld' );
+}
+
+diag "test user creation from email with case mismatch";
+{
+    my $testuser = RT::User->new($RT::SystemUser);
+    my ($ok, $msg) = $testuser->LoadOrCreateByEmail( 'testmail@invalid.tld' );
+    ok( $ok, "create user: $msg" );
+    is( $testuser->Name, 'testmail' );
 }
 
 diag "test form login";


### PR DESCRIPTION
Users expect their username and email address to be case-insensitive. RT's users are case-insensitive, but `RT::Authen::ExternalAuth::DBI` had a bug that caused it to fail if its backing database was case-insensitive.

It used `DBI::selectall_hashref` keyed on the username or email address from the backing database (whichever was used to look up the account), and then retrieved the record from the resulting hash based on the value it had been passed. If the backing database was case-insenitive but case-preserving (as most are) and the case in the database did not match the case used for the query, then the case used to create the hash key would not match the case used to retrieve it. Since Perl hash keys are case-sensitive, the hash dereference would fail and the method would return `undef`, resulting in very strange error messages.

This changes it to use `DBI::selectall_arrayref` and simply use the first record returned. Since the code already checks that exactly one result is returned that change should have no effect on the intended behavior.

I feel like this should have regression tests, but there don't seem to be any tests yet for `ExternalAuth::DBI` and I'm not sure how to mock the external database, so I'm submitting without tests for now. I'll keep looking into how to do it, but I'd appreciate advice if people have any.
