### PR TITLE
Add TicketSQL placeholder for username

### DIFF
--- a/lib/RT/Tickets.pm
+++ b/lib/RT/Tickets.pm
@@ -3116,6 +3116,9 @@ sub _parser {
 
             # replace __CurrentUser__ with id
             $value = $self->CurrentUser->id if $value eq '__CurrentUser__';
+            
+            # replace __CurrentUsername__ with the username
+            $value = $self->CurrentUser->Name if $value eq '__CurrentUsername__';
 
             my $sub = $dispatch{ $class }
                 or die "No dispatch method for class '$class'";


### PR DESCRIPTION
I have seen a lot confusion around the ability to reference just the User->id in TicketSQL. We are using this parse tweak to compare based on the username as well. Not sure if you all except pull requests like this. let me know if there is a different way I should go about doing this.