### PR TITLE
Adapt SMIME probe to work with openssl 1.1

### DIFF
--- a/lib/RT/Crypt/SMIME.pm
+++ b/lib/RT/Crypt/SMIME.pm
@@ -184,6 +184,14 @@ sub Probe {
             \$buf, \$err
         ) };
 
+        if ($err && $err =~ /Invalid command/) {
+            ($buf, $err) = ('', '');
+            safe_run_child { run3( [$bin, "list", "-commands"],
+                \undef,
+                \$buf, \$err
+            ) };
+        }
+
         if ($? or $err) {
             $RT::Logger->warning(
                 "RT's SMIME libraries couldn't successfully execute openssl.".


### PR DESCRIPTION
OpenSSL 1.1 dropped the list-standard-commands command, so also try
'openssl list -commands'.

This has been tested in both Debian unstable (which as of the start of November has OpenSSL 1.1) and stretch (which still has OpenSSL 1.0).