### PR TITLE
Add autocomplete for assets

### DIFF
--- a/share/html/Elements/AddLinks
+++ b/share/html/Elements/AddLinks
@@ -55,8 +55,9 @@ my $id = ($Object and $Object->id)
     ? $Object->id
     : "new";
 
-my $exclude = qq| data-autocomplete="Tickets" data-autocomplete-multiple="1"|;
-$exclude .= qq| data-autocomplete-exclude="$id"| if $Object->id;
+my $exclude = qq| data-autocomplete="TicketsAssets" data-autocomplete-multiple="1"|;
+my @excludes;
+push @excludes, $id if $Object->id;
 </%init>
 % if (ref($Object) eq 'RT::Ticket') {
 <i><&|/l&>Enter tickets or URIs to link tickets to. Separate multiple entries with spaces.</&>
@@ -73,27 +74,57 @@ $exclude .= qq| data-autocomplete-exclude="$id"| if $Object->id;
 <table>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Depends on').':', Relation => 'DependsOn' &></td>
-    <td class="entry"><input name="<%$id%>-DependsOn" value="<% $ARGSRef->{"$id-DependsOn"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_dependson;
+% while (my $link = $Object->DependsOn->Next) {
+%   push @excludes_dependson, ((UNIVERSAL::isa($link->TargetObj, 'RT::Asset') ? 'asset:' : '') . $link->TargetObj->id);
+% }
+% my $exclude_dependson = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_dependson)). '"' if @excludes_dependson || @excludes;
+    <td class="entry"><input name="<%$id%>-DependsOn" value="<% $ARGSRef->{"$id-DependsOn"} || '' %>" <% $exclude_dependson |n%>/></td>
   </tr>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Depended on by').':', Relation => 'DependedOnBy' &></td>
-    <td class="entry"><input name="DependsOn-<%$id%>" value="<% $ARGSRef->{"DependsOn-$id"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_dependedonby;
+% while (my $link = $Object->DependedOnBy->Next) {
+%   push @excludes_dependedonby, ((UNIVERSAL::isa($link->BaseObj, 'RT::Asset') ? 'asset:' : '') . $link->BaseObj->id);
+% }
+% my $exclude_dependonby = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_dependedonby)). '"' if @excludes_dependedonby || @excludes;
+    <td class="entry"><input name="DependsOn-<%$id%>" value="<% $ARGSRef->{"DependsOn-$id"} || '' %>" <% $exclude_dependonby |n%>/></td>
   </tr>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Parents').':', Relation => 'Parents' &></td>
-    <td class="entry"><input name="<%$id%>-MemberOf" value="<% $ARGSRef->{"$id-MemberOf"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_memberof;
+% while (my $link = $Object->MemberOf->Next) {
+%   push @excludes_memberof, ((UNIVERSAL::isa($link->TargetObj, 'RT::Asset') ? 'asset:' : '') . $link->TargetObj->id);
+% }
+% my $exclude_memberof = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_memberof)). '"' if @excludes_memberof || @excludes;
+    <td class="entry"><input name="<%$id%>-MemberOf" value="<% $ARGSRef->{"$id-MemberOf"} || '' %>" <% $exclude_memberof |n%>/></td>
   </tr>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Children').':', Relation => 'Children' &></td>
-    <td class="entry"> <input name="MemberOf-<%$id%>" value="<% $ARGSRef->{"MemberOf-$id"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_members;
+% while (my $link = $Object->Members->Next) {
+%   push @excludes_members, ((UNIVERSAL::isa($link->BaseObj, 'RT::Asset') ? 'asset:' : '') . $link->BaseObj->id);
+% }
+% my $exclude_members = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_members)). '"' if @excludes_members || @excludes;
+    <td class="entry"> <input name="MemberOf-<%$id%>" value="<% $ARGSRef->{"MemberOf-$id"} || '' %>" <% $exclude_members |n%>/></td>
   </tr>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Refers to').':', Relation => 'RefersTo' &></td>
-    <td class="entry"><input name="<%$id%>-RefersTo" value="<% $ARGSRef->{"$id-RefersTo"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_refersto;
+% while (my $link = $Object->RefersTo->Next) {
+%   push @excludes_refersto, ((UNIVERSAL::isa($link->TargetObj, 'RT::Asset') ? 'asset:' : '') . $link->TargetObj->id);
+% }
+% my $exclude_refersto = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_refersto)). '"' if @excludes_refersto || @excludes;
+    <td class="entry"><input name="<%$id%>-RefersTo" value="<% $ARGSRef->{"$id-RefersTo"} || '' %>" <% $exclude_refersto |n%>/></td>
   </tr>
   <tr>
     <td class="label"><& ShowRelationLabel, Object => $Object, Label => loc('Referred to by').':', Relation => 'ReferredToBy' &></td>
-    <td class="entry"> <input name="RefersTo-<%$id%>" value="<% $ARGSRef->{"RefersTo-$id"} || '' %>" <% $exclude |n%>/></td>
+% my @excludes_referredtoby;
+% while (my $link = $Object->ReferredToBy->Next) {
+%   push @excludes_referredtoby, ((UNIVERSAL::isa($link->BaseObj, 'RT::Asset') ? 'asset:' : '') . $link->BaseObj->id);
+% }
+% my $exclude_referredtoby = $exclude . ' data-autocomplete-exclude="' .join(' ', (@excludes, @excludes_referredtoby)). '"' if @excludes_referredtoby || @excludes;
+    <td class="entry"> <input name="RefersTo-<%$id%>" value="<% $ARGSRef->{"RefersTo-$id"} || '' %>" <% $exclude_referredtoby |n%>/></td>
   </tr>
   <& /Elements/EditCustomFields,
         Object          => $Object,

--- a/share/html/Helpers/Autocomplete/Assets
+++ b/share/html/Helpers/Autocomplete/Assets
@@ -1,0 +1,50 @@
+% $r->content_type('application/json; charset=utf-8');
+<% JSON(\@suggestions) |n %>
+% $m->abort;
+
+<%args>
+$term => undef
+$max => undef
+$exclude => ''
+$op => 'LIKE'
+$return_suggestions => 0
+</%args>
+
+<%init>
+# Verify minimum data
+$m->abort unless defined $term
+             and length $term;
+
+my $CurrentUser = $session{'CurrentUser'};
+
+# Require privileged users
+$m->abort unless $CurrentUser->Privileged;
+
+# Sanity check the operator
+$op = 'LIKE' unless $op =~ /^(?:LIKE|(?:START|END)SWITH|=|!=)$/i;
+
+$m->callback(CallbackName => 'ModifyMaxResults', max => \$max);
+$max //= 10;
+
+# Load array of assets
+my $assets = RT::Assets->new($session{'CurrentUser'});
+
+$assets->RowsPerPage($max);
+$assets->LimitToActiveStatus;
+$assets->SimpleSearch(Term => $term);
+
+# Exclude assets we don't want
+foreach (split /\s*,\s*/, $exclude) {
+    $assets->Limit(FIELD => 'id', VALUE => $_, OPERATOR => '!=', ENTRYAGGREGATOR => 'AND', SUBCLAUSE => 'excludeautocomplete');
+}
+
+# Generate suggestions
+my @suggestions;
+while (my $asset = $assets->Next) {
+    my $formatted = loc("#[_1]: [_2] ([_3])", $asset->id, $asset->Name, $asset->Status);
+    my $suggestion = {id => $asset->id, label => $formatted, value => $asset->id};
+    $m->callback(CallbackName => "ModifySuggestion", suggestion => $suggestion, asset => $asset);
+    push @suggestions, $suggestion;
+}
+return @suggestions if $return_suggestions;
+</%init>

--- a/share/html/Helpers/Autocomplete/Tickets
+++ b/share/html/Helpers/Autocomplete/Tickets
@@ -53,6 +53,7 @@ $return => ''
 $term => undef
 $max => undef
 $exclude => ''
+$return_suggestions => 0
 </%ARGS>
 <%INIT>
 # Only allow certain return fields
@@ -62,6 +63,7 @@ $return = 'id'
 $m->abort unless defined $return
              and defined $term
              and length $term;
+
 
 my $CurrentUser = $session{'CurrentUser'};
 
@@ -105,5 +107,6 @@ while ( my $ticket = $tickets->Next ) {
     my $formatted = loc("#[_1]: [_2]", $ticket->Id, $ticket->Subject);
     push @suggestions, { label => $formatted, value => $ticket->$return };
 }
+return @suggestions if $return_suggestions;
 
 </%INIT>

--- a/share/html/Helpers/Autocomplete/TicketsAssets
+++ b/share/html/Helpers/Autocomplete/TicketsAssets
@@ -1,0 +1,26 @@
+% $r->content_type('application/json; charset=utf-8');
+<% JSON( \@suggestions ) |n %>
+% $m->abort;
+<%args>
+$return => ''
+$term => undef
+$max => undef
+$exclude => ''
+</%args>
+<%init>
+my @suggestions;
+my @excludes;
+
+(my $prev, my $type, $term) = $term =~ /^((?:(asset:)?\d+\s+)*)(.*)/;
+@excludes = split ' ', $prev if $prev;
+push @excludes, split ' ', $exclude if $exclude;
+
+if ($term =~ /^asset:./) {
+    my $exclude_assets = join(',', map(/(\d+)/, grep(/^asset:\d+$/, @excludes)));
+    @suggestions = $m->comp('Assets', term => substr($term, 6), max => $max, exclude => $exclude_assets, return_suggestions => 1);
+    @suggestions = map { {id => $_->{id}, label => $_->{label}, value => 'asset:' . $_->{value}} } @suggestions;
+} else {
+    my $exclude_tickets = join(' ', grep(/^\d+$/, @excludes));
+    @suggestions = $m->comp('Tickets', return => $return, term => $term, max => $max, exclude => $exclude_tickets, return_suggestions => 1);
+}
+</%init>

--- a/share/html/Ticket/Elements/ShowAssets
+++ b/share/html/Ticket/Elements/ShowAssets
@@ -206,7 +206,7 @@ if ($ShowRelatedTickets) {
   <div class="add-asset">
     <label>
       <&|/l&>Add an asset to this ticket</&>
-    <input size="10" name="<% $Ticket->id %>-RefersTo" placeholder="<&|/l&>Asset #</&>" type="text">
+    <input size="10" name="<% $Ticket->id %>-RefersTo" placeholder="<&|/l&>Asset #</&>" data-autocomplete="Assets" data-autocomplete-ticketid="<% $Ticket->id %>" data-autocomplete-exclude="<% join(',', @linked_assets) |n %>" type="text" value="">
     </label>
     <input type="submit" value="+">
   </div>

--- a/share/static/js/autocomplete.js
+++ b/share/static/js/autocomplete.js
@@ -5,7 +5,9 @@ window.RT.Autocomplete.Classes = {
     Users: 'user',
     Groups: 'group',
     Tickets: 'tickets',
-    Queues: 'queues'
+    Queues: 'queues',
+    Assets: 'assets',
+    TicketsAssets: 'tickets-assets'
 };
 
 window.RT.Autocomplete.bind = function(from) {
@@ -49,7 +51,7 @@ window.RT.Autocomplete.bind = function(from) {
         }
 
         if (input.is('[data-autocomplete-multiple]')) {
-            if ( what != 'Tickets' ) {
+            if ( what != 'Tickets' && what != 'TicketsAssets' ) {
                 queryargs.push("delim=,");
             }
 
@@ -59,18 +61,18 @@ window.RT.Autocomplete.bind = function(from) {
             }
 
             options.select = function(event, ui) {
-                var terms = this.value.split(what == 'Tickets' ? /\s+/ : /,\s*/);
+                var terms = this.value.split((what == 'Tickets' || what == 'TicketsAssets') ? /\s+/ : /,\s*/);
                 terms.pop();                    // remove current input
                 terms.push( ui.item.value );    // add selected item
-                if ( what == 'Tickets' ) {
+                if ( what == 'Tickets' || what == 'TicketsAssets') {
                     // remove non-integers in case subject search with spaces in (like "foo bar")
                     terms = jQuery.grep(terms, function(term) {
                         var str = term + ''; // stringify integers to call .match
-                        return str.match(/^\d+$/);
+                        return str.match(/^(?:asset:)?\d+$/);
                     } );
                 }
                 terms.push(''); // add trailing delimeter so user can input another value directly
-                this.value = terms.join(what == 'Tickets' ? ' ' : ", ");
+                this.value = terms.join((what == 'Tickets' || what == 'TicketsAssets') ? ' ' : ", ");
                 jQuery(this).change();
 
                 return false;


### PR DESCRIPTION
Add support of autocompletion for assets (with RT::Assets-SimpleSearch,
therefore using RT->Config->Get('AssetSearchFields') and
RT->Config->Get('DefaultCatalog')) in field "Add an asset to this
ticket" of the ticket display form.

Also add support of completion both for tickets and for assets in each
input field of the AddLinks form. Completion is done for tickets (as
usual) until the entered term starts with "asset:", where the completion
is switched for assets.

Signed-off-by: gibus <gibus@easter-eggs.com>

(NB: I've previously submitted this patch on https://issues.bestpractical.com/Ticket/Display.html?id=29204 but was advised by @elacour that code review may be easier with a pull request on github)