### PR TITLE
Add Conditional CustomFields

### DIFF
--- a/docs/initialdata.pod
+++ b/docs/initialdata.pod
@@ -240,6 +240,18 @@ value.  A clever way to do this easily is with a simple variable you increment
 each time (as above with C<$i>).  You can use the same variable throughout the
 whole file, and don't need one per CF.
 
+=item C<ConditionedBy>
+
+Name or ID of a Custom Field Value. This makes the CF be available only if
+another Select Custom Field (defined by C<ConditionedByCF>, if pased as Name,
+or directly linked to this value if passed as ID) is set with this value.
+
+=item C<ConditionedByCF>
+
+Name or ID of another Custom Field. This makes the CF be available only if
+the named Select Custom Field is set to the value defined by C<ConditionedBy>.
+Only used if C<ConditionedBy> is defined as a Name.
+
 =item C<BasedOn>
 
 Name or ID of another Select Custom Field.  This makes the named CF the source

--- a/etc/schema.Oracle
+++ b/etc/schema.Oracle
@@ -352,6 +352,7 @@ CREATE TABLE CustomFields (
         MaxValues         NUMBER(11,0) DEFAULT 0 NOT NULL,
         Pattern           CLOB,
         ValuesClass       VARCHAR2(64),
+        ConditionedBy     NUMBER(11,0) NULL,
         BasedOn           NUMBER(11,0) NULL,
         Description       VARCHAR2(255),
         SortOrder         NUMBER(11,0) DEFAULT 0 NOT NULL,

--- a/etc/schema.Pg
+++ b/etc/schema.Pg
@@ -535,6 +535,7 @@ CREATE TABLE CustomFields (
   RenderType varchar(64) NULL  ,
   MaxValues integer NOT NULL DEFAULT 0  ,
   ValuesClass varchar(64) NULL  ,
+  ConditionedBy integer NULL, 
   BasedOn integer NULL, 
   Pattern varchar(65536) NULL  ,
   LookupType varchar(255) NOT NULL  ,

--- a/etc/schema.SQLite
+++ b/etc/schema.SQLite
@@ -381,6 +381,7 @@ CREATE TABLE CustomFields (
   RenderType varchar(64) collate NOCASE NULL  ,
   MaxValues integer,            # New -- was 'Single'(1) and 'Multiple'(0)
   Pattern varchar(65536) collate NOCASE NULL  ,        # New -- Must validate against this
+  ConditionedBy INTEGER NULL,
   BasedOn INTEGER NULL,
   ValuesClass varchar(64) collate NOCASE NULL  ,
   Description varchar(255) collate NOCASE NULL  ,

--- a/etc/schema.mysql
+++ b/etc/schema.mysql
@@ -353,6 +353,7 @@ CREATE TABLE CustomFields (
   RenderType varchar(64) CHARACTER SET ascii NULL  ,
   MaxValues integer,            # New -- was 'Single'(1) and 'Multiple'(0)
   Pattern TEXT NULL  ,  # New -- Must validate against this
+  ConditionedBy INTEGER NULL,
   BasedOn INTEGER NULL,
   ValuesClass varchar(64) CHARACTER SET ascii NULL  ,
   Description varchar(255) NULL  ,

--- a/etc/upgrade/4.4.2/schema.Oracle
+++ b/etc/upgrade/4.4.2/schema.Oracle
@@ -1,2 +1,3 @@
 ALTER TABLE CustomFields ADD UniqueValues NUMBER(11,0) DEFAULT 0 NOT NULL;
 ALTER TABLE CustomFields ADD CanonicalizeClass VARCHAR2(64);
+ALTER TABLE CustomFields ADD ConditionedBy NUMBER(11,0) NULL;

--- a/etc/upgrade/4.4.2/schema.Pg
+++ b/etc/upgrade/4.4.2/schema.Pg
@@ -1,2 +1,3 @@
 ALTER TABLE CustomFields ADD COLUMN UniqueValues integer NOT NULL DEFAULT 0;
 ALTER TABLE CustomFields ADD COLUMN CanonicalizeClass varchar(64) NULL;
+ALTER TABLE CustomFields ADD COLUMN ConditionedBy INTEGER NULL;

--- a/etc/upgrade/4.4.2/schema.SQLite
+++ b/etc/upgrade/4.4.2/schema.SQLite
@@ -1,2 +1,3 @@
 ALTER TABLE CustomFields ADD COLUMN UniqueValues int2 NOT NULL DEFAULT 0;
 ALTER TABLE CustomFields ADD COLUMN CanonicalizeClass varchar(64) collate NOCASE NULL;
+ALTER TABLE CustomFields ADD COLUMN ConditionedBy INTEGER NULL;

--- a/etc/upgrade/4.4.2/schema.mysql
+++ b/etc/upgrade/4.4.2/schema.mysql
@@ -1,2 +1,3 @@
 ALTER TABLE CustomFields ADD COLUMN UniqueValues int2 NOT NULL DEFAULT 0;
 ALTER TABLE CustomFields ADD COLUMN CanonicalizeClass varchar(64) CHARACTER SET ascii NULL;
+ALTER TABLE CustomFields ADD COLUMN ConditionedBy INTEGER NULL;

--- a/share/html/Admin/CustomFields/Modify.html
+++ b/share/html/Admin/CustomFields/Modify.html
@@ -155,6 +155,60 @@ jQuery( function() {
 <i><&|/l&>Some browsers may only load content from the same domain as your RT server.</&></i>
 </div></td></tr>
 
+% if ( $CustomFieldObj->Id ) {
+<script type="text/javascript">
+jQuery( function() {
+    var select = jQuery('select[name=ConditionalCF]');
+    select.change(function() {
+        var cf_id = jQuery(this).find('option:selected').val();
+        if (cf_id) {
+            jQuery.getJSON('/Helpers/SelectCondition', {CustomFieldId: cf_id}, function(values) {
+                if (values) {
+                    jQuery('select[name=ConditionedBy] option').each(function() {
+                        if (jQuery(this).val()) {
+                            jQuery(this).remove();
+                        }
+                    });
+                    jQuery.each(values, function(id, val) {
+                        jQuery('select[name=ConditionedBy]').append(jQuery('<option>', {value: id, text: val}));
+                    });
+                }
+            });
+            jQuery('.conditional-field-condition').show();
+        } else {
+            jQuery('select[name=ConditionedBy] option').each(function() {
+                if (jQuery(this).val()) {
+                    jQuery(this).remove();
+                }
+            });
+            jQuery('.conditional-field-condition').hide();
+        }
+    });
+});
+</script>
+<tr class="conditionedby"><td class="label"><&|/l&>Customfield is conditioned by</&></td><td>
+% my $default = 0;
+% $default = $CustomFieldObj->ConditionedByObj->CustomFieldObj if $CustomFieldObj->ConditionedByObj && $CustomFieldObj->ConditionedByObj->id;
+% $default = $ConditionalCF if $ConditionalCF;
+<& /Admin/Elements/SelectCustomField,
+    Name => "ConditionalCF",
+    LookupType => $CustomFieldObj->LookupType,
+    Default => $default,
+    Not => $CustomFieldObj->id,
+&>
+<span class="conditional-field-condition"<% $CustomFieldObj->ConditionedByObj->id || $ConditionedBy ? '' : 'style="display: none;"' |n%>>
+<span class="label">is</span>
+<select name="ConditionedBy">
+% if ($CustomFieldObj->ConditionedByObj->id || $ConditionedBy) {
+%   $ConditionedBy ||= $CustomFieldObj->ConditionedByObj->id;
+%   my $cf_values = $CustomFieldObj->ConditionedByObj->CustomFieldObj->Values;
+%   while (my $cf_value = $cf_values->Next) {
+<option value="<% $cf_value->id %>"<% $cf_value->id == $ConditionedBy ? qq[ selected="selected"] : '' |n%>><% $cf_value->Name %></option>
+%   }
+% }
+</select></span></td></tr>
+% }
+
 % if ( $CustomFieldObj->Id && $CustomFieldObj->IsSelectionType ) {
 <tr class="categoriesbasedon"><td class="label"><&|/l&>Categories are based on</&></td><td>
 <& /Admin/Elements/SelectCustomField,
@@ -222,6 +276,7 @@ else {
             Pattern       => $Pattern,
             LinkValueTo   => $LinkValueTo,
             IncludeContentForValue => $IncludeContentForValue,
+            ConditionedBy => $ConditionedBy,
             BasedOn       => $BasedOn,
             Disabled      => ($Enabled ? 0 : 1),
             EntryHint     => $EntryHint,
@@ -323,6 +378,11 @@ if ( $ARGS{'Update'} && $id ne 'new' ) {
     else {
         # Delete it if we no longer support render types
         $CustomFieldObj->SetRenderType( undef );
+    }
+
+    if (($CustomFieldObj->ConditionedBy||'') ne ($ConditionedBy||'')) {
+        my ($good, $msg) = $CustomFieldObj->SetConditionedBy( $ConditionedBy );
+        push @results, $msg;
     }
 
     if (($CustomFieldObj->BasedOn||'') ne ($BasedOn||'')) {
@@ -430,6 +490,8 @@ $CanonicalizeClass => undef
 $RenderType => undef
 $LinkValueTo => undef
 $IncludeContentForValue => undef
+$ConditionalCF => undef
+$ConditionedBy => undef
 $BasedOn => undef
 $EntryHint => undef
 </%ARGS>

--- a/share/html/Admin/Groups/Modify.html
+++ b/share/html/Admin/Groups/Modify.html
@@ -71,6 +71,7 @@
 </tr>
 % my $CFs = $Group->CustomFields;
 % while (my $CF = $CFs->Next) {
+% next if $Group->ConditionNotMet($CF);
 <tr valign="top"><td align="right">
 <% $CF->Name %>:
 </td><td>

--- a/share/html/Admin/Queues/Modify.html
+++ b/share/html/Admin/Queues/Modify.html
@@ -107,6 +107,7 @@ checked="checked"
 
 % my $CFs = $QueueObj->CustomFields;
 % while (my $CF = $CFs->Next) {
+% next if $QueueObj->ConditionNotMet($CF);
 <tr valign="top"><td align="right">
 <% $CF->Name %>:
 </td><td>

--- a/share/html/Articles/Article/Elements/EditCustomFields
+++ b/share/html/Articles/Article/Elements/EditCustomFields
@@ -47,6 +47,7 @@
 %# END BPS TAGGED BLOCK }}}
 <table>
 % while (my $CustomField = $CustomFields->Next()) {
+% next if $ArticleObj->ConditionNotMet($CustomField);
 <tr>
     <td class="cflabel">
         <span class="name"><%$CustomField->Name%>:</span><br />

--- a/share/html/Elements/EditCustomFields
+++ b/share/html/Elements/EditCustomFields
@@ -59,6 +59,7 @@
 <<% $WRAP %> class="edit-custom-fields">
 % }
 % for my $CustomField (@CustomFields) {
+% next if $Object->ConditionNotMet($CustomField);
 % my $Type = $CustomField->Type || 'Unknown';
 % my @classes = (
 %   'edit-custom-field',

--- a/share/html/Elements/ShowCustomFields
+++ b/share/html/Elements/ShowCustomFields
@@ -51,6 +51,7 @@
 <table>
 % }
 % while ( my $CustomField = $CustomFields->Next ) {
+% next if $Object->ConditionNotMet($CustomField);
 % my $Values = $Object->CustomFieldValues( $CustomField->Id );
 % my $count = $Values->Count;
 % next if $HideEmpty and not $count;

--- a/share/html/Helpers/SelectCondition
+++ b/share/html/Helpers/SelectCondition
@@ -1,0 +1,18 @@
+<%args>
+$CustomFieldId => undef
+</%args>
+<%init>
+my $result = undef;
+if ($CustomFieldId) {
+    my $cf = RT::CustomField->new($session{'CurrentUser'});
+    $cf->Load($CustomFieldId);
+    if ($cf->id) {
+        my $cf_values = $cf->Values;
+        while (my $cf_value = $cf_values->Next) {
+            $result->{$cf_value->id} = $cf_value->Name;
+        }
+    }
+}
+$m->out(JSON($result));
+$m->abort;
+</%init>


### PR DESCRIPTION
Allows to set up any Custom Field to be conditional. A conditional CF is attached to an object (ticket, queue, user, group, asset, article) if and only if the condition is met for this object. As for categories, a conditions is set up by specifying another Select Custom Field attached to the same object and a value which this Select CF should have for this condition to be met.