### PR TITLE
Also search in $RT::LocalEtcPath for RT_SiteConfig.d includes

### DIFF
--- a/lib/RT/Config.pm
+++ b/lib/RT/Config.pm
@@ -1241,7 +1241,8 @@ sub LoadConfig {
         delete $INC{$load};
 
         my $dir = $ENV{RT_SITE_CONFIG_DIR} || "$RT::EtcPath/RT_SiteConfig.d";
-        for my $file ( sort <$dir/*.pm> ) {
+        my $localdir = $ENV{RT_SITE_CONFIG_DIR} || "$RT::LocalEtcPath/RT_SiteConfig.d";
+        for my $file ( sort(<$dir/*.pm>), sort(<$localdir/*.pm>) ) {
             $self->_LoadConfig( %args, File => $file, Site => 1, Extension => '' );
             delete $INC{$file};
         }


### PR DESCRIPTION
This matches the dual-loading of RT_SiteConfig.pm and is needed for Debian.