### PR TITLE
make "Name" field and CFs wider for Admin/Groups/Modify.html

### DIFF
--- a/share/html/Admin/Groups/Modify.html
+++ b/share/html/Admin/Groups/Modify.html
@@ -60,31 +60,34 @@
 <input type="hidden" class="hidden" name="id" value="<%$Group->Id%>" />
 % }
 <table>
-<tr><td align="right">
-<&|/l&>Name</&>:
-</td>
-<td><input name="Name" value="<%$Group->Name||$Name||''%>" /></td>
-</tr>
-<tr>
-<td align="right">
-<&|/l&>Description</&>:</td><td colspan="3"><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
-</tr>
+    <tr>
+        <td align="right"><&|/l&>Name</&>:</td>
+        <td><input name="Name" value="<%$Group->Name||$Name||''%>" size="60"/></td>
+    </tr>
+    <tr>
+        <td align="right"><&|/l&>Description</&>:</td>
+        <td><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
+    </tr>
 % my $CFs = $Group->CustomFields;
 % while (my $CF = $CFs->Next) {
-<tr valign="top"><td align="right">
-<% $CF->Name %>:
-</td><td>
-<& /Elements/EditCustomField, CustomField => $CF, 
-                              Object => $Group, &>
-</td></tr>
+    <tr valign="top">
+        <td align="right"><% $CF->Name %>:</td>
+        <td>
+            <& /Elements/EditCustomField,
+                CustomField => $CF,
+                Object      => $Group,
+                Cols        => 60,
+            &>
+        </td>
+    </tr>
 % }
-<tr>
-<td colspan="2">
-<input type="hidden" class="hidden" name="SetEnabled" value="1" />
-<input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked%> />
-<label for="Enabled"><&|/l&>Enabled (Unchecking this box disables this group)</&></label><br />
-</td>
-</tr>
+    <tr>
+        <td colspan="2">
+            <input type="hidden" class="hidden" name="SetEnabled" value="1" />
+            <input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked%> />
+            <label for="Enabled"><&|/l&>Enabled (Unchecking this box disables this group)</&></label><br />
+        </td>
+    </tr>
 % $m->callback( %ARGS, GroupObj => $Group, results => \@results );
 </table>
 % if ( $Create ) {


### PR DESCRIPTION
We are using some slightly longer group names, however due to the
(unnecessarily) short input field, we can't see the complete value of
what we are typing.

There is plenty of horizontal real estate, so bump the size of the Name
input.

Make the CF size consistent with Name and Description, too.

Remove extraneous (and wrong) 'colspan="3"' for Description table cell.

Reformat table cell tags for readability.