### PR TITLE
Fix logging of users IP address when RT is hosted behind a reverse proxy

### DIFF
--- a/lib/RT/Authen/ExternalAuth.pm
+++ b/lib/RT/Authen/ExternalAuth.pm
@@ -445,7 +445,9 @@ sub DoAuth {
             $RT::Logger->info(  "Successful login for",
                                 $session->{'CurrentUser'}->Name,
                                 "from",
-                                ( RT::Interface::Web::RequestENV('REMOTE_ADDR') || 'UNKNOWN') );
+                                ( RT::Interface::Web::RequestENV('HTTP_X_FORWARDED_FOR')
+                                    || RT::Interface::Web::RequestENV('REMOTE_ADDR')
+                                    || 'UNKNOWN') );
             # Do not delete the session. User stays logged in and
             # autohandler will not check the password again
 

--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -821,7 +821,7 @@ sub AttemptPasswordAuthentication {
 
     my $m = $HTML::Mason::Commands::m;
 
-    my $remote_addr = RequestENV('REMOTE_ADDR');
+    my $remote_addr = RequestENV('HTTP_X_FORWARDED_FOR') || RequestENV('REMOTE_ADDR');
     unless ( $user_obj->id && $user_obj->IsPassword( $ARGS->{pass} ) ) {
         $RT::Logger->error("FAILED LOGIN for @{[$ARGS->{user}]} from $remote_addr");
         $m->callback( %$ARGS, CallbackName => 'FailedLogin', CallbackPage => '/autohandler' );

--- a/share/html/Elements/ShowCustomFieldWikitext
+++ b/share/html/Elements/ShowCustomFieldWikitext
@@ -50,23 +50,16 @@
 my $content = $Object->LargeContent || $Object->Content;
 $content = $m->comp('/Elements/ScrubHTML', Content => $content);
 my $base = $Object->Object->WikiBase;
-my %wiki_tags = ();
 my %wiki_args = (
     extended => 1,
     absolute_links => 1,
     implicit_links => RT->Config->Get('WikiImplicitLinks'),
     prefix => $base,
 );
-$m->callback(
-    CallbackName => 'WikiFormatArgs',
-    ARGSRef => \%ARGS,
-    WikiArgsRef => \%wiki_args,
-    WikiTagsRef => \%wiki_tags,
-    ContentRef => \$content
-);
+$m->callback( CallbackName => 'WikiFormatArgs', ARGSRef => \%ARGS, WikiArgsRef => \%wiki_args, ContentRef => \$content);
 
 use Text::WikiFormat;
-my $wiki_content = Text::WikiFormat::format( $content."\n" , { %wiki_tags }, { %wiki_args } );
+my $wiki_content = Text::WikiFormat::format( $content."\n" , {}, { %wiki_args } );
 </%init>
 <%ARGS>
 $Object

--- a/share/html/Elements/ShowCustomFieldWikitext
+++ b/share/html/Elements/ShowCustomFieldWikitext
@@ -50,16 +50,23 @@
 my $content = $Object->LargeContent || $Object->Content;
 $content = $m->comp('/Elements/ScrubHTML', Content => $content);
 my $base = $Object->Object->WikiBase;
+my %wiki_tags = ();
 my %wiki_args = (
     extended => 1,
     absolute_links => 1,
     implicit_links => RT->Config->Get('WikiImplicitLinks'),
     prefix => $base,
 );
-$m->callback( CallbackName => 'WikiFormatArgs', ARGSRef => \%ARGS, WikiArgsRef => \%wiki_args, ContentRef => \$content);
+$m->callback(
+    CallbackName => 'WikiFormatArgs',
+    ARGSRef => \%ARGS,
+    WikiArgsRef => \%wiki_args,
+    WikiTagsRef => \%wiki_tags,
+    ContentRef => \$content
+);
 
 use Text::WikiFormat;
-my $wiki_content = Text::WikiFormat::format( $content."\n" , {}, { %wiki_args } );
+my $wiki_content = Text::WikiFormat::format( $content."\n" , { %wiki_tags }, { %wiki_args } );
 </%init>
 <%ARGS>
 $Object


### PR DESCRIPTION
Patch ensures that the clients ip address is logged if the proxy is configured to pass the information using the widely used X_FORWARDED_FOR header.