### PR TITLE
Fix logging of users IP address when RT is hosted behind a reverse proxy

### DIFF
--- a/lib/RT/Authen/ExternalAuth.pm
+++ b/lib/RT/Authen/ExternalAuth.pm
@@ -445,7 +445,9 @@ sub DoAuth {
             $RT::Logger->info(  "Successful login for",
                                 $session->{'CurrentUser'}->Name,
                                 "from",
-                                ( RT::Interface::Web::RequestENV('REMOTE_ADDR') || 'UNKNOWN') );
+                                ( RT::Interface::Web::RequestENV('HTTP_X_FORWARDED_FOR')
+                                    || RT::Interface::Web::RequestENV('REMOTE_ADDR')
+                                    || 'UNKNOWN') );
             # Do not delete the session. User stays logged in and
             # autohandler will not check the password again
 

--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -821,7 +821,7 @@ sub AttemptPasswordAuthentication {
 
     my $m = $HTML::Mason::Commands::m;
 
-    my $remote_addr = RequestENV('REMOTE_ADDR');
+    my $remote_addr = RequestENV('HTTP_X_FORWARDED_FOR') || RequestENV('REMOTE_ADDR');
     unless ( $user_obj->id && $user_obj->IsPassword( $ARGS->{pass} ) ) {
         $RT::Logger->error("FAILED LOGIN for @{[$ARGS->{user}]} from $remote_addr");
         $m->callback( %$ARGS, CallbackName => 'FailedLogin', CallbackPage => '/autohandler' );


### PR DESCRIPTION
Patch ensures that the clients ip address is logged if the proxy is configured to pass the information using the widely used X_FORWARDED_FOR header.