### PR TITLE
Add ability to modify Text::WikiFormat tags from WikiFormatArgs callback

### DIFF
--- a/share/html/Elements/ShowCustomFieldWikitext
+++ b/share/html/Elements/ShowCustomFieldWikitext
@@ -50,16 +50,23 @@
 my $content = $Object->LargeContent || $Object->Content;
 $content = $m->comp('/Elements/ScrubHTML', Content => $content);
 my $base = $Object->Object->WikiBase;
+my %wiki_tags = ();
 my %wiki_args = (
     extended => 1,
     absolute_links => 1,
     implicit_links => RT->Config->Get('WikiImplicitLinks'),
     prefix => $base,
 );
-$m->callback( CallbackName => 'WikiFormatArgs', ARGSRef => \%ARGS, WikiArgsRef => \%wiki_args, ContentRef => \$content);
+$m->callback(
+    CallbackName => 'WikiFormatArgs',
+    ARGSRef => \%ARGS,
+    WikiArgsRef => \%wiki_args,
+    WikiTagsRef => \%wiki_tags,
+    ContentRef => \$content
+);
 
 use Text::WikiFormat;
-my $wiki_content = Text::WikiFormat::format( $content."\n" , {}, { %wiki_args } );
+my $wiki_content = Text::WikiFormat::format( $content."\n" , { %wiki_tags }, { %wiki_args } );
 </%init>
 <%ARGS>
 $Object


### PR DESCRIPTION
This can be used to either modify the html that is created or redefine how a block is identified.
Details of how it works can be found here:
    http://search.cpan.org/~cycles/Text-WikiFormat-0.81/lib/Text/WikiFormat.pm#Blocks
