### PR TITLE
Need a new Callback for RT-Extention-AttachmentZip

### DIFF
--- a/share/html/Ticket/Elements/ShowAttachments
+++ b/share/html/Ticket/Elements/ShowAttachments
@@ -51,7 +51,7 @@
         color => "#336699",
         hide_chrome => $HideTitleBox &>
         
-% $m->callback( CallbackName => 'AfterAttachmentTitleBox', %ARGS, TicketObj => $Ticket );        
+% $m->callback( %ARGS, CallbackName => 'AfterAttachmentTitleBox', TicketObj => $Ticket );        
 
 <div class="attachment-list">
 

--- a/share/html/Ticket/Elements/ShowAttachments
+++ b/share/html/Ticket/Elements/ShowAttachments
@@ -51,7 +51,7 @@
         color => "#336699",
         hide_chrome => $HideTitleBox &>
         
-$m->callback( CallbackName => 'AfterAttachmentTitleBox', %ARGS, TicketObj => $TicketObj );        
+% $m->callback( CallbackName => 'AfterAttachmentTitleBox', %ARGS, TicketObj => $Ticket );        
 
 <div class="attachment-list">
 

--- a/share/html/Ticket/Elements/ShowAttachments
+++ b/share/html/Ticket/Elements/ShowAttachments
@@ -50,6 +50,8 @@
         class => 'ticket-info-attachments',
         color => "#336699",
         hide_chrome => $HideTitleBox &>
+        
+$m->callback( CallbackName => 'AfterAttachmentTitleBox', %ARGS, TicketObj => $TicketObj );        
 
 <div class="attachment-list">
 


### PR DESCRIPTION
Hi Bps,
i'm rewriting the old RTx::AttachmentZip at the moment to get it running under RT 4.4. To make it in a clean way, i would like to request a new Callback for ShowAttachments called AfterAttachmentTitelBox.

Hope it is ok this way.