### PR TITLE
4.4/group name input size

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -4522,6 +4522,50 @@ sub GetCustomFieldInputNamePrefix {
     RT::Interface::Web::GetCustomFieldInputNamePrefix(@_);
 }
 
+=head2 HTMLifyClassAttribute
+
+Given a parameter list (of scalars or array references), return
+a space separated joined string of all parameters.
+
+Example:
+
+HTMLifyClassAttribute(
+    'error',
+    undef,
+    [
+        'inventory',
+        'missing',
+    ],
+    'capital equipment',
+)
+
+would return:
+
+"error inventory missing capital equipment"
+
+=cut
+
+sub HTMLifyClassAttribute {
+    my @aggregate_classes = ();
+
+    # iterate over parameters and extend array as needed...
+    for my $potential_class (@_) {
+        if (defined $potential_class) {
+            if (ref($potential_class) eq ref(q{})) {
+                # potential_class is a scalar
+                push @aggregate_classes, $potential_class;
+            }
+            elsif (ref($potential_class) eq ref([])) {
+                # potential_class is an array ref
+                push @aggregate_classes, @$potential_class;
+            }
+        }
+    }
+
+    # make array consumable by HTML...
+    return join ' ', @aggregate_classes;
+}
+
 package RT::Interface::Web;
 RT::Base->_ImportOverlays();
 

--- a/share/html/Admin/Groups/Modify.html
+++ b/share/html/Admin/Groups/Modify.html
@@ -62,11 +62,11 @@
 <table>
     <tr>
         <td align="right"><&|/l&>Name</&>:</td>
-        <td><input name="Name" value="<%$Group->Name||$Name||''%>" /></td>
+        <td><input name="Name" value="<%$Group->Name||$Name||''%>" class="<% $input_html_classes %>" /></td>
     </tr>
     <tr>
         <td align="right"><&|/l&>Description</&>:</td>
-        <td><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
+        <td><input name="Description" value="<%$Group->Description||$Description||''%>" class="<% $input_html_classes %>" /></td>
     </tr>
 % my $CFs = $Group->CustomFields;
 % while (my $CF = $CFs->Next) {
@@ -76,6 +76,7 @@
             <& /Elements/EditCustomField,
                 CustomField => $CF,
                 Object      => $Group,
+                Classes     => $input_html_classes,
             &>
         </td>
     </tr>
@@ -165,6 +166,7 @@ push @results, @warnings;
 
 $EnabledChecked = ( $Group->Disabled() ? '' : 'checked="checked"' );
 
+my $input_html_classes = 'admin groups input';
 </%INIT>
 
 

--- a/share/html/Admin/Groups/Modify.html
+++ b/share/html/Admin/Groups/Modify.html
@@ -60,31 +60,33 @@
 <input type="hidden" class="hidden" name="id" value="<%$Group->Id%>" />
 % }
 <table>
-<tr><td align="right">
-<&|/l&>Name</&>:
-</td>
-<td><input name="Name" value="<%$Group->Name||$Name||''%>" /></td>
-</tr>
-<tr>
-<td align="right">
-<&|/l&>Description</&>:</td><td colspan="3"><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
-</tr>
+    <tr>
+        <td align="right"><&|/l&>Name</&>:</td>
+        <td><input name="Name" value="<%$Group->Name||$Name||''%>" /></td>
+    </tr>
+    <tr>
+        <td align="right"><&|/l&>Description</&>:</td>
+        <td colspan="3"><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
+    </tr>
 % my $CFs = $Group->CustomFields;
 % while (my $CF = $CFs->Next) {
-<tr valign="top"><td align="right">
-<% $CF->Name %>:
-</td><td>
-<& /Elements/EditCustomField, CustomField => $CF, 
-                              Object => $Group, &>
-</td></tr>
+    <tr valign="top">
+        <td align="right"><% $CF->Name %>:</td>
+        <td>
+            <& /Elements/EditCustomField,
+                CustomField => $CF,
+                Object      => $Group,
+            &>
+        </td>
+    </tr>
 % }
-<tr>
-<td colspan="2">
-<input type="hidden" class="hidden" name="SetEnabled" value="1" />
-<input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked%> />
-<label for="Enabled"><&|/l&>Enabled (Unchecking this box disables this group)</&></label><br />
-</td>
-</tr>
+    <tr>
+        <td colspan="2">
+            <input type="hidden" class="hidden" name="SetEnabled" value="1" />
+            <input type="checkbox" class="checkbox" id="Enabled" name="Enabled" value="1" <%$EnabledChecked%> />
+            <label for="Enabled"><&|/l&>Enabled (Unchecking this box disables this group)</&></label><br />
+        </td>
+    </tr>
 % $m->callback( %ARGS, GroupObj => $Group, results => \@results );
 </table>
 % if ( $Create ) {

--- a/share/html/Admin/Groups/Modify.html
+++ b/share/html/Admin/Groups/Modify.html
@@ -66,7 +66,7 @@
     </tr>
     <tr>
         <td align="right"><&|/l&>Description</&>:</td>
-        <td colspan="3"><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
+        <td><input name="Description" value="<%$Group->Description||$Description||''%>" size="60" /></td>
     </tr>
 % my $CFs = $Group->CustomFields;
 % while (my $CF = $CFs->Next) {

--- a/share/html/Elements/EditCustomField
+++ b/share/html/Elements/EditCustomField
@@ -140,6 +140,7 @@ return $m->comp(
     NamePrefix => $NamePrefix,
     CustomField => $CustomField,
     Name => $Name,
+    Classes => $Classes,
     $CustomField->BasedOn && $Name ? ( BasedOnName => GetCustomFieldInputName(Object => $Object, CustomField => $CustomField->BasedOnObj, Grouping => $Grouping) ) : (),
 );
 </%INIT>
@@ -151,5 +152,6 @@ $NamePrefix  => undef
 $Rows        => 5
 $Cols        => 15
 $Default     => undef
+$Classes     => undef
 $DefaultsFromTopArguments => 1,
 </%ARGS>

--- a/share/html/Elements/EditCustomFieldFreeform
+++ b/share/html/Elements/EditCustomFieldFreeform
@@ -54,13 +54,13 @@ cols="<% $Cols %>" \
 % if ( defined $Rows ) {
 rows="<% $Rows %>" \
 % }
-name="<%$name%>" id="<%$name%>" wrap="off" class="CF-<%$CustomField->id%>-Edit"><% defined($Default) ? $Default : '' %></textarea>
+name="<%$name%>" id="<%$name%>" wrap="off" class="<% $Classes %>"><% defined($Default) ? $Default : '' %></textarea>
 % } else {
 <input type="text" name="<%$name%>" id="<%$name%>" \
 % if ( defined $Cols ) {
 size="<% $Cols %>" \
 % }
-class="CF-<%$CustomField->id%>-Edit" value="<% defined($Default) ? $Default : ''%>" />
+class="<% $Classes %>" value="<% defined($Default) ? $Default : ''%>" />
 % }
 <%INIT>
 if ( $Multiple and $Values ) {
@@ -69,6 +69,11 @@ if ( $Multiple and $Values ) {
 unless ( $Multiple ) {
     $Default =~ s/\s*\n+\s*/ /g if $Default;
 }
+
+$Classes = HTMLifyClassAttribute(
+    'CF-'.$CustomField->id.'-Edit',
+    $Classes,
+);
 </%INIT>
 <%ARGS>
 $Object => undef
@@ -78,6 +83,7 @@ $Name => undef
 $Default => undef
 $Values => undef
 $Multiple => undef
+$Classes => undef
 $Cols
 $Rows
 </%ARGS>

--- a/share/html/Elements/EditCustomFieldText
+++ b/share/html/Elements/EditCustomFieldText
@@ -53,7 +53,7 @@ cols="<% $Cols %>" \
 % if ( defined $Rows ) {
 rows="<% $Rows %>" \
 % }
-name="<%$name%>" class="CF-<%$CustomField->id%>-Edit"><% $value->Content %></textarea><br />
+name="<%$name%>" class="<% $Classes %>"><% $value->Content %></textarea><br />
 % }
 % if (!$MaxValues or !$Values or $Values->Count < $MaxValues) {
 <textarea \
@@ -63,12 +63,17 @@ cols="<% $Cols %>" \
 % if ( defined $Rows ) {
 rows="<% $Rows %>" \
 % }
-name="<%$name%>" class="CF-<%$CustomField->id%>-Edit"><% defined($Default) ? $Default : '' %></textarea>
+name="<%$name%>" class="<% $Classes %>"><% defined($Default) ? $Default : '' %></textarea>
 % }
 <%INIT>
 # XXX - MultiValue textarea is for now outlawed.
 $MaxValues = 1;
 my $name = $Name || $NamePrefix . $CustomField->Id . '-Values';
+
+$Classes = HTMLifyClassAttribute(
+    'CF-'.$CustomField->id.'-Edit',
+    $Classes,
+);
 </%INIT>
 <%ARGS>
 $Object => undef
@@ -78,6 +83,7 @@ $Name => undef
 $Default => undef
 $Values => undef
 $MaxValues => undef
+$Classes => undef
 $Cols
 $Rows
 </%ARGS>

--- a/share/html/Ticket/Update.html
+++ b/share/html/Ticket/Update.html
@@ -258,6 +258,12 @@ jQuery( function() {
    }
 
    jQuery("#ticket-update-metadata :input, #UpdateCc, #UpdateBcc").change( updateScrips );
+
+   jQuery("body").on("submit", "form", function () {
+       jQuery("#recipients input[name=TxnSendMailToAll], #recipients input[name=TxnSendMailTo]").attr('disabled', false);
+       jQuery("#previewscrips input[name=TxnSendMailToAll], #previewscrips input[name=TxnSendMailTo]").attr('disabled', false);
+   });
+
 });
 </script>
 % }

--- a/share/static/css/base/forms.css
+++ b/share/static/css/base/forms.css
@@ -29,7 +29,9 @@ form {
     font-style: italic;
 }
 
-
+.admin.groups.input {
+    width: 40em;
+}
 
 div.button-row {
    text-align: right;


### PR DESCRIPTION
BPS,

In talking with Jim we discussed some of these changes. The main divergence is extending /Elements/EditCustomField to take a $Classes parameter to extend the class attribute of the rendered HTML for the /Elements/EditCustomField* components.

I couldn't bring myself to sully the component call (in /Admin/Groups/Modify.html) with "Cols => X" when everything else was in CSS.

Let me know what you think.

Also, somehow Shawn's commit (https://github.com/mzagrabe/rt/commit/1846c153c2fe5a294500660f1d4d36735f4c2d5a) got included in this PR. <confused/>

-m