### PR TITLE
Use all SquelchMailTo on Ticket Create

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -476,7 +476,7 @@ sub Create {
     if ($args{'SquelchMailTo'}) {
        my @squelch = ref( $args{'SquelchMailTo'} ) ? @{ $args{'SquelchMailTo'} }
         : $args{'SquelchMailTo'};
-        $self->_SquelchMailTo( @squelch );
+        $self->_SquelchMailTo( $_ ) for @squelch;
     }
 
     # Add all the custom fields


### PR DESCRIPTION
originally from [bestpractical.com #174642]

The _SquelchMailTo method only uses the first value in @_ and silently discards the rest