### PR TITLE
LDAP Import: Size check can differ to actual result size

### DIFF
--- a/lib/RT/LDAPImport.pm
+++ b/lib/RT/LDAPImport.pm
@@ -472,8 +472,7 @@ sub _run_search {
         push @results, $result->entries;
 
         # Short circuit early if we're done
-        last if not $result->count
-             or $result->count < ($RT::LDAPSizeLimit || 0);
+        last if not $result->count;
 
         if ($page) {
             if (my $control = $result->control( LDAP_CONTROL_PAGED )) {


### PR DESCRIPTION
Hi,

the problem with this setting is that actual page size can differ from configured value. For example:

- LDAP with 30K users
- LDAP server delivers 3000 results at once
- LDAPSizeLimit is 5000

This means only the first 3000 users are imported because we jump out of the loop.

Kind regards,
Marius