### PR TITLE
callback after table opens for Ticket/Create.html

### DIFF
--- a/share/html/Ticket/Create.html
+++ b/share/html/Ticket/Create.html
@@ -143,6 +143,7 @@
 <div id="ticket-create-message">
   <&| /Widgets/TitleBox, title => $title, class => 'messagedetails' &>
 <table border="0" cellpadding="0" cellspacing="0">
+% $m->callback(CallbackName => 'AfterTableOpens', QueueObj => $QueueObj, ARGSRef => \%ARGS);
 <tr>
 <td class="label">
 <&|/l&>Requestors</&>:


### PR DESCRIPTION
BPS,

I have a need for a callback before the requestors table row on Ticket/Create.html. This patch should do it. I'm open to a different name for the callback and/or a different placement of the callback in the DOM as long as I can get a TR before the Requestors TR.

Let me know what you think.

-m