### PR TITLE
add CreatorObj reference to Default callback

### DIFF
--- a/share/html/Elements/ShowTransaction
+++ b/share/html/Elements/ShowTransaction
@@ -57,7 +57,7 @@
 % $m->callback( %ARGS, Transaction => $Transaction, CallbackName => 'AfterAnchor' );
     <span class="date"><% $date |n %></span>
     <span class="description">
-      <& /Elements/ShowUser, User => $Transaction->CreatorObj &> - <% $desc |n %>
+      <& /Elements/ShowUser, User => $CreatorObj &> - <% $desc |n %>
 % $m->callback( %ARGS, Transaction => $Transaction, CallbackName => 'AfterDescription' );
     </span>
 % if ( $Object->isa("RT::Ticket") and $Object->CurrentUserCanSeeTime ) {
@@ -227,6 +227,8 @@ elsif ( %$Attachments && $ShowActions ) {
     }
 }
 
+my $CreatorObj = $Transaction->CreatorObj;
+
 $m->callback(
     %ARGS,
     Transaction => $Transaction,
@@ -238,6 +240,7 @@ $m->callback(
     TimeTaken   => \$time,
     Description => \$desc,
     ShowBody    => \$ShowBody,
+    CreatorObj  => \$CreatorObj,
 );
 
 my $actions = '';


### PR DESCRIPTION
Use a lexical scope variable for CreatorObj and expose it to default
callback via a reference argument.

This allows admins to modify the Creator that gets displayed for the
transaction.