### PR TITLE
Improved User-Interaction for Attachments

### DIFF
--- a/share/html/Elements/JavascriptConfig
+++ b/share/html/Elements/JavascriptConfig
@@ -49,7 +49,7 @@
 my $Config = {};
 $Config->{$_} = RT->Config->Get( $_, $session{CurrentUser} )
   for qw(rtname WebPath MessageBoxRichText MessageBoxRichTextHeight
-         MessageBoxUseSystemContextMenu);
+         MessageBoxUseSystemContextMenu MaxAttachmentSize);
 
 my $CurrentUser = {};
 if ($session{CurrentUser} and $session{CurrentUser}->id) {

--- a/share/html/Ticket/Elements/AddAttachments
+++ b/share/html/Ticket/Elements/AddAttachments
@@ -69,7 +69,7 @@ jQuery( function() {
         url: RT.Config.WebHomePath + '/Helpers/Upload/Add?Token=' + jQuery('#attach-dropzone').closest('form').find('input[name=Token]').val(),
         paramName: "Attach",
         dictDefaultMessage: <% loc("Drop files here or click to attach") |n,j %>,
-        maxFilesize: 10000,
+        maxFilesize: 10,
         previewTemplate: '' +
             '<div class="dz-preview dz-file-preview">' +
             '    <div class="dz-remove-mark pointer-events" data-dz-remove>' +

--- a/share/html/Ticket/Elements/AddAttachments
+++ b/share/html/Ticket/Elements/AddAttachments
@@ -63,13 +63,16 @@
         <div class="dropzone" id="attach-dropzone">
         </div>
 <script type="text/javascript">
+%# Scale down the Attachment size from KiB to MiB since that is what "Dropzone" expects
+var MaxAttachmentSizeScaled = RT.Config.MaxAttachmentSize/(1024*1024) >> 0;
+
 Dropzone.autoDiscover = false;
 jQuery( function() {
     var attachDropzone = new Dropzone('#attach-dropzone', {
         url: RT.Config.WebHomePath + '/Helpers/Upload/Add?Token=' + jQuery('#attach-dropzone').closest('form').find('input[name=Token]').val(),
         paramName: "Attach",
         dictDefaultMessage: <% loc("Drop files here or click to attach") |n,j %>,
-        maxFilesize: 10,
+        maxFilesize: MaxAttachmentSizeScaled,
         previewTemplate: '' +
             '<div class="dz-preview dz-file-preview">' +
             '    <div class="dz-remove-mark pointer-events" data-dz-remove>' +


### PR DESCRIPTION
The Dropzone Function expects MiB, not KiB, therefor the previous 10000 would result in an upload limit of 10GiB.
Setting it to 10 actually gives the user a feedback that his attachment size is too big, with the previous code the attachment just gets dropped due to the backend crashing (mysql can only handle a limited package size) and leaves the user puzzled.

The best way would be to get the $MaxAttachmentSize setting from the user config and correct its unit, but my attempts failed. This is the best approach i have so far:
<% use integer; RT->Config->Get('$MaxAttachmentSize') / 1024 %>