### PR TITLE
Fix "Unescaped left brace in regex" warning in perl 5.26

### DIFF
--- a/share/html/Search/Elements/EditSort
+++ b/share/html/Search/Elements/EditSort
@@ -119,7 +119,7 @@ $fields{$_} = $_ for @cfs;
 # Add all available CustomRoles to the list of sortable columns.
 my @roles = grep /^CustomRole/, @{$ARGS{AvailableColumns}};
 for my $role (@roles) {
-    my ($label) = $role =~ /^CustomRole.{(.*)}$/;
+    my ($label) = $role =~ /^CustomRole.\{(.*)\}$/;
     my $value = $role;
     $fields{$label . '.EmailAddress' } = $value . '.EmailAddress';
 }


### PR DESCRIPTION
Originally reported in Debian as https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=865047