### PR TITLE
Removed a 'fix-this' comment for battle tested code

### DIFF
--- a/share/html/Elements/ColumnMap
+++ b/share/html/Elements/ColumnMap
@@ -54,7 +54,6 @@ $Attr  => undef
 
 use Scalar::Util;
 
-# This is scary and should totally be refactored -- jesse
 my ($COLUMN_MAP, $WCOLUMN_MAP);
 $WCOLUMN_MAP = $COLUMN_MAP = {
     id => {


### PR DESCRIPTION
Stumbled over this 10 year old comment about code needing to be refactored. According to Jesse Vincent on twitter, the code is battle tested, and the comment can be removed, ref https://twitter.com/obra/status/885597840268906498