### PR TITLE
Update Ticket.pm, allow Forward From in ARGS

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -3137,6 +3137,7 @@ sub Forward {
         Bcc            => '',
         Content        => '',
         ContentType    => 'text/plain',
+        From           => undef,
         @_
     );
 
@@ -3156,14 +3157,21 @@ sub Forward {
 
     $mime->head->replace( $_ => Encode::encode('UTF-8',$args{$_} ) )
       for grep defined $args{$_}, qw(Subject To Cc Bcc);
-    $mime->head->replace(
-        From => Encode::encode( 'UTF-8',
-            RT::Interface::Email::GetForwardFrom(
-                Transaction => $args{Transaction},
-                Ticket      => $self,
+
+   if ($args{From}) {
+        $mime->head->replace(
+            From => Encode::encode( 'UTF-8', $args{From} )
+        );
+    } else {       
+        $mime->head->replace(
+            From => Encode::encode( 'UTF-8',
+                RT::Interface::Email::GetForwardFrom(
+                    Transaction => $args{Transaction},
+                    Ticket      => $self,
+                )
             )
-        )
-    );
+        );
+    }
 
     for my $argument (qw(Encrypt Sign)) {
         if ( defined $args{ $argument } ) {


### PR DESCRIPTION
this minor change allows the From Address for Forwards to be passed in in args

if "From"  is set it is used as the mail From Address in the mail header

if it is not set the Default behavior is not touched

I use this to set the From address to be set as desired by the user in 
https://github.com/MarkHofstetter/RT-Extension-SelectBoxForwardFrom