### PR TITLE
_FillInTemplateURL(): check for empty CF

### DIFF
--- a/lib/RT/ObjectCustomFieldValue.pm
+++ b/lib/RT/ObjectCustomFieldValue.pm
@@ -343,6 +343,7 @@ sub _FillInTemplateURL {
     # special case, whole value should be an URL
     if ( $url =~ /^__CustomField__/ ) {
         my $value = $self->Content;
+        $value = '' if !defined($value);
         # protect from potentially malicious URLs
         if ( $value =~ /^\s*(?:javascript|data):/i ) {
             my $object = $self->Object;


### PR DESCRIPTION
The original code generates two warnings "Use of uninitialized value $value" for empty custom fields.
The same fix is applied for placeholders a few lines below.