### PR TITLE
Set proper HTTP Status codes on Abort

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -72,6 +72,7 @@ use Digest::MD5 ();
 use List::MoreUtils qw();
 use JSON qw();
 use Plack::Util;
+use HTTP::Status qw();
 
 =head2 SquishedCSS $style
 
@@ -2038,6 +2039,10 @@ sub Abort {
     my $why  = shift;
     my %args = @_;
 
+    $args{Code} //= HTTP::Status::HTTP_OK;
+
+    $r->headers_out->{'Status'} = $args{Code} . ' ' . HTTP::Status::status_message($args{Code});
+
     if (   $session{'ErrorDocument'}
         && $session{'ErrorDocumentType'} )
     {
@@ -2140,11 +2145,11 @@ sub CreateTicket {
 
     my $Queue = RT::Queue->new( $current_user );
     unless ( $Queue->Load( $ARGS{'Queue'} ) ) {
-        Abort('Queue not found');
+        Abort('Queue not found', Code => HTTP::Status::HTTP_NOT_FOUND);
     }
 
     unless ( $Queue->CurrentUserHasRight('CreateTicket') ) {
-        Abort('You have no permission to create tickets in that queue.');
+        Abort('You have no permission to create tickets in that queue.', Code => HTTP::Status::HTTP_FORBIDDEN);
     }
 
     my $due;
@@ -2257,7 +2262,7 @@ sub CreateTicket {
 
     push( @Actions, split( "\n", $ErrMsg ) );
     unless ( $Ticket->CurrentUserHasRight('ShowTicket') ) {
-        Abort( "No permission to view newly created ticket #" . $Ticket->id . "." );
+        Abort( "No permission to view newly created ticket #" . $Ticket->id . ".", Code => HTTP::Status::HTTP_FORBIDDEN );
     }
     return ( $Ticket, @Actions );
 
@@ -2282,13 +2287,13 @@ sub LoadTicket {
     }
 
     unless ($id) {
-        Abort("No ticket specified");
+        Abort("No ticket specified", Code => HTTP::Status::HTTP_BAD_REQUEST);
     }
 
     my $Ticket = RT::Ticket->new( $session{'CurrentUser'} );
     $Ticket->Load($id);
     unless ( $Ticket->id ) {
-        Abort("Could not load ticket $id");
+        Abort("Could not load ticket $id", Code => HTTP::Status::HTTP_NOT_FOUND);
     }
     return $Ticket;
 }

--- a/lib/RT/Test/Web.pm
+++ b/lib/RT/Test/Web.pm
@@ -55,6 +55,7 @@ use base qw(Test::WWW::Mechanize);
 use MIME::Base64 qw//;
 use Encode 'encode_utf8';
 use Storable 'thaw';
+use HTTP::Status qw();
 
 BEGIN { require RT::Test; }
 require Test::More;
@@ -126,7 +127,7 @@ sub logged_in_as {
     my $self = shift;
     my $user = shift || '';
 
-    unless ( $self->status == 200 ) {
+    unless ( $self->status == HTTP::Status::HTTP_OK ) {
         Test::More::diag( "error: status is ". $self->status );
         return 0;
     }
@@ -144,12 +145,12 @@ sub logout {
     my $url = $self->rt_base_url;
     $self->get($url);
     Test::More::diag( "error: status is ". $self->status )
-        unless $self->status == 200;
+        unless $self->status == HTTP::Status::HTTP_OK;
 
     if ( $self->content =~ /Logout/i ) {
         $self->follow_link( text => 'Logout' );
         Test::More::diag( "error: status is ". $self->status ." when tried to logout" )
-            unless $self->status == 200;
+            unless $self->status == HTTP::Status::HTTP_OK;
     }
     else {
         return 1;
@@ -167,6 +168,7 @@ sub goto_ticket {
     my $self = shift;
     my $id   = shift;
     my $view = shift || 'Display';
+    my $status = shift || HTTP::Status::HTTP_OK;
     unless ( $id && int $id ) {
         Test::More::diag( "error: wrong id ". defined $id? $id : '(undef)' );
         return 0;
@@ -175,7 +177,7 @@ sub goto_ticket {
     my $url = $self->rt_base_url;
     $url .= "Ticket/${ view }.html?id=$id";
     $self->get($url);
-    unless ( $self->status == 200 ) {
+    unless ( $self->status == $status ) {
         Test::More::diag( "error: status is ". $self->status );
         return 0;
     }

--- a/share/html/Dashboards/Modify.html
+++ b/share/html/Dashboards/Modify.html
@@ -92,7 +92,7 @@ my $Dashboard = RT::Dashboard->new($session{'CurrentUser'});
 my $method = $Create ? 'ObjectsForCreating' : 'ObjectsForModifying';
 my @privacies = $Dashboard->$method;
 
-Abort(loc("Permission Denied")) if @privacies == 0;
+Abort(loc("Permission Denied"), Code => HTTP::Status::HTTP_FORBIDDEN) if @privacies == 0;
 
 if ($Create) {
     $title = loc("Create a new dashboard");
@@ -149,10 +149,13 @@ if (!$Create && !$tried_create && $id && $ARGS{'Save'}) {
 my $can_delete = $Dashboard->CurrentUserCanDelete;
 
 if (!$Create && !$tried_create && $id && $ARGS{'Delete'}) {
+    if (!$can_delete) {
+        Abort(loc("Couldn't delete dashboard [_1]: Permission denied", $id), Code => HTTP::Status::HTTP_FORBIDDEN);
+    }
     my ($ok, $msg) = $Dashboard->Delete();
     if (!$ok) {
-             Abort(loc("Couldn't delete dashboard [_1]: [_2]", $id, $msg));
-             }
+        Abort(loc("Couldn't delete dashboard [_1]: [_2]", $id, $msg), Code => HTTP::Status::HTTP_BAD_REQUEST);
+    }
 
     push @results, $msg;
     $redirect_to = '/Dashboards/index.html';

--- a/share/html/Ticket/Attachment/WithHeaders/dhandler
+++ b/share/html/Ticket/Attachment/WithHeaders/dhandler
@@ -50,13 +50,13 @@
     my ($id) = $m->dhandler_arg =~ /^(\d+)/;
     unless ( $id ) {
         # wrong url format
-        Abort("Corrupted attachment URL");
+        Abort("Corrupted attachment URL", Code => HTTP::Status::HTTP_BAD_REQUEST);
     }
 
     my $AttachmentObj = RT::Attachment->new( $session{'CurrentUser'} );
     $AttachmentObj->Load( $id );
     unless ( $AttachmentObj->id ) {
-        Abort("Couldn't load attachment #$id");
+        Abort("Couldn't load attachment #$id", Code => HTTP::Status::HTTP_NOT_FOUND);
     }
 
     my $content_type = 'text/plain';

--- a/share/html/Ticket/Attachment/dhandler
+++ b/share/html/Ticket/Attachment/dhandler
@@ -53,16 +53,16 @@ if ( $arg =~ m{^(\d+)/(\d+)} ) {
     $attach = $2;
 }
 else {
-    Abort("Corrupted attachment URL.");
+    Abort("Corrupted attachment URL.", Code => HTTP::Status::HTTP_BAD_REQUEST);
 }
 my $AttachmentObj = RT::Attachment->new( $session{'CurrentUser'} );
-$AttachmentObj->Load($attach) || Abort("Attachment '$attach' could not be loaded");
+$AttachmentObj->Load($attach) || Abort("Attachment '$attach' could not be loaded", Code => HTTP::Status::HTTP_NOT_FOUND);
 
 unless ( $AttachmentObj->id ) {
-    Abort("Bad attachment id. Couldn't find attachment '$attach'\n");
+    Abort("Bad attachment id. Couldn't find attachment '$attach'\n", Code => HTTP::Status::HTTP_NOT_FOUND);
 }
 unless ( $AttachmentObj->TransactionId() == $trans ) {
-    Abort("Bad transaction number for attachment. $trans should be". $AttachmentObj->TransactionId() . "\n");
+    Abort("Bad transaction number for attachment. $trans should be". $AttachmentObj->TransactionId() . "\n", Code => HTTP::Status::HTTP_NOT_FOUND);
 }
 
 my $content = $AttachmentObj->OriginalContent;

--- a/share/html/Ticket/Create.html
+++ b/share/html/Ticket/Create.html
@@ -366,7 +366,7 @@ my $current_user = $session{'CurrentUser'};
 if ($CloneTicket) {
     my $CloneTicketObj = RT::Ticket->new( $session{CurrentUser} );
     $CloneTicketObj->Load($CloneTicket)
-        or Abort( loc("Ticket could not be loaded") );
+        or Abort( loc("Ticket could not be loaded"), Code => HTTP::Status::HTTP_BAD_REQUEST );
 
     my $clone = {
         Requestors => join( ',', $CloneTicketObj->RequestorAddresses ),
@@ -438,7 +438,7 @@ if ($CloneTicket) {
 my @results;
 
 my $QueueObj = RT::Queue->new($current_user);
-$QueueObj->Load($Queue) || Abort(loc("Queue [_1] could not be loaded.", $Queue||''));
+$QueueObj->Load($Queue) || Abort(loc("Queue [_1] could not be loaded.", $Queue||''), Code => HTTP::Status::HTTP_BAD_REQUEST);
 
 my $title = loc("Create a new ticket in [_1]", $m->scomp("/Ticket/Elements/ShowQueue", QueueObj => $QueueObj));
 
@@ -446,7 +446,7 @@ $m->callback( QueueObj => $QueueObj, title => \$title, results => \@results, ARG
 
 $m->scomp( '/Articles/Elements/SubjectOverride', ARGSRef => \%ARGS, QueueObj => $QueueObj, results => \@results );
 
-$QueueObj->Disabled && Abort(loc("Cannot create tickets in a disabled queue."));
+$QueueObj->Disabled && Abort(loc("Cannot create tickets in a disabled queue."), Code => HTTP::Status::HTTP_NOT_FOUND);
 
 my $ticket = RT::Ticket->new($current_user); # empty ticket object
 

--- a/share/html/Ticket/Display.html
+++ b/share/html/Ticket/Display.html
@@ -133,7 +133,7 @@ my (@Actions, $title);
 
 
 unless ($id || $TicketObj) {
-    Abort('No ticket specified');
+    Abort('No ticket specified', Code => HTTP::Status::HTTP_BAD_REQUEST);
 }
 
 if ($ARGS{'id'} eq 'new') {
@@ -142,16 +142,16 @@ if ($ARGS{'id'} eq 'new') {
     my $Queue = RT::Queue->new( $session{'CurrentUser'} );
     $Queue->Load($ARGS{'Queue'});
     unless ( $Queue->id ) {
-        Abort('Queue not found');
+        Abort('Queue not found', Code => HTTP::Status::HTTP_NOT_FOUND);
     }
 
     unless ( $Queue->CurrentUserHasRight('CreateTicket') ) {
-        Abort('You have no permission to create tickets in that queue.');
+        Abort('You have no permission to create tickets in that queue.', Code => HTTP::Status::HTTP_FORBIDDEN);
     }
 
     ($TicketObj, @Actions) = CreateTicket( %ARGS );
     unless ( $TicketObj->CurrentUserHasRight('ShowTicket') ) {
-        Abort("No permission to view newly created ticket #".$TicketObj->id.".");
+        Abort("No permission to view newly created ticket #".$TicketObj->id.".", Code => HTTP::Status::HTTP_FORBIDDEN);
     }
 } else { 
     $TicketObj ||= LoadTicket($ARGS{'id'});
@@ -197,9 +197,9 @@ if ($ARGS{'id'} eq 'new') {
     if ( !$SkipProcessing ) {
         unless ($TicketObj->CurrentUserHasRight('ShowTicket')) {
             if (@Actions) {
-                Abort("A change was applied successfully, but you no longer have permissions to view the ticket", Actions => \@Actions);
+                Abort("A change was applied successfully, but you no longer have permissions to view the ticket", Actions => \@Actions, Code => HTTP::Status::HTTP_FORBIDDEN);
             } else {
-                Abort("No permission to view ticket");
+                Abort("No permission to view ticket", Code => HTTP::Status::HTTP_FORBIDDEN);
             }
         }
         if ( $ARGS{'MarkAsSeen'} ) {

--- a/t/externalauth/auth_config.t
+++ b/t/externalauth/auth_config.t
@@ -37,6 +37,15 @@ Set($ExternalSettings, {
 END
 
 }
+
+BEGIN {
+  # $config above implicitly loads Net::LDAP because of type ldap
+  eval { require RT::Authen::ExternalAuth; require Net::LDAP::Server::Test; 1; } or do {
+    use RT::Test tests => undef;
+    plan skip_all => 'Unable to test without Net::LDAP and Net::LDAP::Server::Test';
+  };
+}
+
 use RT::Test nodb => 1, tests => undef, config => $config;
 use Test::Warn;
 

--- a/t/security/CVE-2011-2084-attach-tickets.t
+++ b/t/security/CVE-2011-2084-attach-tickets.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use RT::Test tests => undef;
+use HTTP::Status qw();
 
 my $user = RT::Test->load_or_create_user(
     Name            => 'user',
@@ -39,7 +40,8 @@ my $ticket_b = RT::Test->last_ticket;
 my ($baseurl, $m) = RT::Test->started_ok;
 ok $m->login( 'user', 'password' ), 'logged in as user';
 
-$m->get_ok("$baseurl/Ticket/Display.html?id=" . $ticket_b->id);
+$m->get("$baseurl/Ticket/Display.html?id=" . $ticket_b->id);
+is($m->status, HTTP::Status::HTTP_FORBIDDEN, 'No permission to view ticket.');
 $m->content_contains('No permission');
 $m->warning_like(qr/no permission/i, 'no permission warning');
 

--- a/t/web/compilation_errors.t
+++ b/t/web/compilation_errors.t
@@ -2,12 +2,14 @@ use strict;
 use warnings;
 use Test::More;
 use File::Find;
+use HTTP::Status qw();
+
 BEGIN {
     sub wanted {
         -f && /\.html$/ && $_ !~ /Logout.html$/ && $File::Find::dir !~ /RichText/;
     }
     my $tests = 7;
-    find( sub { wanted() and $tests += 4 }, 'share/html/' );
+    find( sub { wanted() and $tests += 3 }, 'share/html/' );
     plan tests => $tests + 1; # plus one for warnings check
 }
 
@@ -28,11 +30,11 @@ $agent->cookie_jar($cookie_jar);
 my $url = $agent->rt_base_url;
 $agent->get($url);
 
-is($agent->status, 200, "Loaded a page");
+is($agent->status, HTTP::Status::HTTP_OK, "Loaded a page");
 
 # follow the link marked "Login"
 $agent->login(root => 'password');
-is($agent->status, 200, "Fetched the page ok");
+is($agent->status, HTTP::Status::HTTP_OK, "Fetched the page ok");
 $agent->content_contains('Logout', "Found a logout link");
 
 
@@ -48,8 +50,8 @@ sub test_get {
         $file =~ s#^share/html/##;
         diag( "testing $url/$file" );
 
-        $agent->get_ok("$url/$file");
-        is($agent->status, 200, "Loaded $file");
+        $agent->get("$url/$file");
+        isnt($agent->status, HTTP::Status::HTTP_INTERNAL_SERVER_ERROR, "Loaded $file");
         $agent->content_lacks('Not logged in', "Still logged in for  $file");
         $agent->content_lacks('raw error', "Didn't get a Mason compilation error on $file") or do {
             if (my ($error) = $agent->content =~ /<pre>(.*?line.*?)$/s) {

--- a/t/web/csrf.t
+++ b/t/web/csrf.t
@@ -147,7 +147,7 @@ $m->title_is('Possible cross-site request forgery');
 # Create.html errors out.
 my $link = $m->find_link(text_regex => qr{resume your request});
 (my $broken_url = $link->url) =~ s/(CSRF_Token)=\w+/$1=crud/;
-$m->get_ok($broken_url);
+$m->get($broken_url);
 $m->content_like(qr/Queue\s+could not be loaded/);
 $m->title_is('RT Error');
 $m->warning_like(qr/Queue\s+could not be loaded/);

--- a/t/web/dashboards-basics.t
+++ b/t/web/dashboards-basics.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use HTTP::Status qw();
 use RT::Test tests => 105;
 my ($baseurl, $m) = RT::Test->started_ok;
 
@@ -40,7 +41,8 @@ $m->content_lacks('<a href="/Dashboards/Modify.html?Create=1">New</a>',
 
 $m->no_warnings_ok;
 
-$m->get_ok($url."Dashboards/Modify.html?Create=1");
+$m->get($url."Dashboards/Modify.html?Create=1");
+is($m->status, HTTP::Status::HTTP_FORBIDDEN);
 $m->content_contains("Permission Denied");
 $m->content_lacks("Save Changes");
 
@@ -49,7 +51,8 @@ $m->warning_like(qr/Permission Denied/, "got a permission denied warning");
 $user_obj->PrincipalObj->GrantRight(Right => 'ModifyOwnDashboard', Object => $RT::System);
 
 # Modify itself is no longer good enough, you need Create
-$m->get_ok($url."Dashboards/Modify.html?Create=1");
+$m->get($url."Dashboards/Modify.html?Create=1");
+is($m->status, HTTP::Status::HTTP_FORBIDDEN);
 $m->content_contains("Permission Denied");
 $m->content_lacks("Save Changes");
 
@@ -150,7 +153,8 @@ $m->content_unlike( qr/Bookmarked Tickets.*Bookmarked Tickets/s,
     'only dashboard queries show up' );
 $m->content_contains("dashboard test", "ticket subject");
 
-$m->get_ok("/Dashboards/Modify.html?id=$id&Delete=1");
+$m->get("/Dashboards/Modify.html?id=$id&Delete=1");
+is($m->status, HTTP::Status::HTTP_FORBIDDEN);
 $m->content_contains("Permission Denied", "unable to delete dashboard because we lack DeleteOwnDashboard");
 
 $m->warning_like(qr/Couldn't delete dashboard.*Permission Denied/, "got a permission denied warning when trying to delete the dashboard");

--- a/t/web/path-traversal.t
+++ b/t/web/path-traversal.t
@@ -1,49 +1,51 @@
 use strict;
 use warnings;
 
+use HTTP::Status qw();
 use RT::Test tests => undef;
 
 my ($baseurl, $agent) = RT::Test->started_ok;
 ok($agent->login);
 
 $agent->get("$baseurl/NoAuth/../Elements/HeaderJavascript");
-is($agent->status, 400);
+is($agent->status, HTTP::Status::HTTP_BAD_REQUEST);
 $agent->warning_like(qr/Invalid request.*aborting/);
 
 $agent->get("$baseurl/NoAuth/../%45lements/HeaderJavascript");
-is($agent->status, 400);
+is($agent->status, HTTP::Status::HTTP_BAD_REQUEST);
 $agent->warning_like(qr/Invalid request.*aborting/);
 
 $agent->get("$baseurl/NoAuth/%2E%2E/Elements/HeaderJavascript");
-is($agent->status, 400);
+is($agent->status, HTTP::Status::HTTP_BAD_REQUEST);
 $agent->warning_like(qr/Invalid request.*aborting/);
 
 $agent->get("$baseurl/NoAuth/../../../etc/RT_Config.pm");
-is($agent->status, 400);
+is($agent->status, HTTP::Status::HTTP_BAD_REQUEST);
 $agent->warning_like(qr/Invalid request.*aborting/) unless $ENV{RT_TEST_WEB_HANDLER} =~ /^apache/;
 
 $agent->get("$baseurl/static/css/web2/images/../../../../../../etc/RT_Config.pm");
-# Apache hardcodes a 400m but the static handler returns a 403 for traversal too high
-is($agent->status, $ENV{RT_TEST_WEB_HANDLER} =~ /^apache/ ? 400 : 403);
+# Apache hardcodes a 400 but the static handler returns a 403 for traversal too high
+is($agent->status, $ENV{RT_TEST_WEB_HANDLER} =~ /^apache/ ? HTTP::Status::HTTP_BAD_REQUEST : HTTP::Status::HTTP_FORBIDDEN);
 
 # Do not reject a simple /. in the URL, for downloading uploaded
 # dotfiles, for example.
 $agent->get("$baseurl/Ticket/Attachment/28/9/.bashrc");
-is($agent->status, 200); # Even for a file not found, we return 200
+is($agent->status, HTTP::Status::HTTP_NOT_FOUND);
+#print $agent->content;
 $agent->next_warning_like(qr/could not be loaded/, "couldn't loaded warning");
 $agent->content_like(qr/Attachment \S+ could not be loaded/);
 
 # do not reject these URLs, even though they contain /. outside the path
 $agent->get("$baseurl/index.html?ignored=%2F%2E");
-is($agent->status, 200);
+is($agent->status, HTTP::Status::HTTP_OK);
 
 $agent->get("$baseurl/index.html?ignored=/.");
-is($agent->status, 200);
+is($agent->status, HTTP::Status::HTTP_OK);
 
 $agent->get("$baseurl/index.html#%2F%2E");
-is($agent->status, 200);
+is($agent->status, HTTP::Status::HTTP_OK);
 
 $agent->get("$baseurl/index.html#/.");
-is($agent->status, 200);
+is($agent->status, HTTP::Status::HTTP_OK);
 
 done_testing;

--- a/t/web/ticket_display.t
+++ b/t/web/ticket_display.t
@@ -44,7 +44,8 @@ diag "test ShowTicket right";
         'got no permission warning' );
 
 
-    $m->goto_ticket($id);
+    $m->goto_ticket($id, undef, HTTP::Status::HTTP_FORBIDDEN);
+    is($m->status, HTTP::Status::HTTP_FORBIDDEN, 'No permission');
     $m->content_contains( "No permission to view ticket",
         'got no permission msg' );
     $m->warning_like( qr/No permission to view ticket/, 'got warning' );


### PR DESCRIPTION
Initially implemented because Google's crawler was complaining that "Ticket not found" pages did not have a 404 status code.

This doesn't set status codes for all Aborts, but does the common ones.  If there's consensus as to what it should be (500?) there could be a default status on all Abort calls.