### PR TITLE
Fix acl and indexes upgrades

### DIFF
--- a/lib/RT/Handle.pm
+++ b/lib/RT/Handle.pm
@@ -468,7 +468,7 @@ sub InsertACL {
     }
 
     local *acl;
-    do $path || return (0, "Couldn't load ACLs: " . $@);
+    do $path || return (0, "Couldn't load ACLs from '$path': " . ($@ || $!));
     my @acl = acl($dbh);
     foreach my $statement (@acl) {
         my $sth = $dbh->prepare($statement)

--- a/sbin/rt-setup-database.in
+++ b/sbin/rt-setup-database.in
@@ -278,9 +278,10 @@ sub action_acl {
     return ($status, $msg) unless $status;
 
     my $individual_id = Data::GUID->new->as_string();
+    my $filename = Cwd::abs_path($args{'datafile'} || $args{'datadir'} || '');
     my %upgrade_data = (
         action   => 'acl',
-        filename => Cwd::abs_path($args{'datafile'} || $args{'datadir'} || ''),
+        filename => $filename,
         stage    => 'before',
         full_id  => $full_id,
         individual_id => $individual_id,
@@ -289,7 +290,7 @@ sub action_acl {
     RT->System->AddUpgradeHistory($package => \%upgrade_data) if $log_actions;
 
     print "Now inserting database ACLs.\n";
-    my @ret = RT::Handle->InsertACL( $dbh, $args{'datafile'} || $args{'datadir'} );
+    my @ret = RT::Handle->InsertACL( $dbh, $filename );
 
     %upgrade_data = (
         stage         => 'after',
@@ -305,9 +306,10 @@ sub action_indexes {
     my %args = @_;
     RT->ConnectToDatabase;
     my $individual_id = Data::GUID->new->as_string();
+    my $filename = Cwd::abs_path($args{'datafile'} || $args{'datadir'} || '');
     my %upgrade_data = (
         action   => 'indexes',
-        filename => Cwd::abs_path($args{'datafile'} || $args{'datadir'} || ''),
+        filename => $filename,
         stage    => 'before',
         full_id  => $full_id,
         individual_id => $individual_id,
@@ -321,7 +323,7 @@ sub action_indexes {
     RT::InitLogging();
 
     print "Now inserting database indexes.\n";
-    my @ret = RT::Handle->InsertIndexes( $dbh, $args{'datafile'} || $args{'datadir'} );
+    my @ret = RT::Handle->InsertIndexes( $dbh, $filename );
 
     $RT::Handle = RT::Handle->new;
     $RT::Handle->dbh( undef );


### PR DESCRIPTION
- improve error reporting for `RT::Handle->InsertACL`
- use absolute paths for `InsertACL` and `InsertIndexes` in rt-setup-database

  Since perl 5.25.7 '.' might not be present in `@INC` by default, see: https://metacpan.org/pod/release/EXODIST/perl-5.25.7/pod/perldelta.pod#'.'-and-@INC

Also see https://forum.bestpractical.com/t/upgrading-through-rt4-1-1-fails-with-couldnt-load-acls/31855