### PR TITLE
ignore missing dependencies listed in RT_IGNORE_DEPENDENCIES

### DIFF
--- a/sbin/rt-test-dependencies.in
+++ b/sbin/rt-test-dependencies.in
@@ -109,6 +109,8 @@ $args{$_} = $default{$_} foreach grep {!exists $args{$_}} keys %default;
 $args{'with-EXTERNALAUTH-TESTS'}
     = $args{'with-EXTERNALAUTH'} && $args{'with-DEVELOPER'};
 
+my %IGNORE_DEPS = map { chomp; $_ => 1 } split(',', ($ENV{'RT_IGNORE_DEPENDENCIES'} || ''));
+
 $deps{'CORE'} = [ text_to_hash( << '.') ];
 Apache::Session 1.53
 Business::Hours
@@ -429,6 +431,7 @@ sub test_deps {
     while (@deps) {
         my $module  = shift @deps;
         my $version = shift @deps;
+        next if $IGNORE_DEPS{$module};
         my ( $test, $error ) = test_dep( $module, $version, $AVOID{$module} );
         my $msg = $module . ( $version && !$error ? " >= $version" : '' );
         print_found( $msg, $test, $error );


### PR DESCRIPTION
I need to ignore the `Mozilla::CA` dependency; on debian `LWP::Protocol::https` [doesn't use it][1], and debian [isn't going to package `Mozilla::CA`][2].

With `RT_IGNORE_DEPENDENCIES` I can simply run

```shell
export RT_IGNORE_DEPENDENCIES=Mozilla::CA
```

before `make install` and friends without having to modify the source.

[1]: https://anonscm.debian.org/cgit/pkg-perl/packages/liblwp-protocol-https-perl.git/tree/debian/patches/cert.patch
[2]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=702124