### PR TITLE
Small adaptions for Articles

### DIFF
--- a/lib/RT/Record.pm
+++ b/lib/RT/Record.pm
@@ -1305,8 +1305,12 @@ sub FormatLink {
                  @_
                );
     my $text = "URI " . $args{FallBack};
-    if ($args{Object} && $args{Object}->isa("RT::Ticket")) {
-        $text = "Ticket " . $args{Object}->id;
+    if ($args{Object}) {
+        if ($args{Object}->isa("RT::Ticket")) {
+            $text = "Ticket " . $args{Object}->id;
+        } elsif ($args{Object}->isa("RT::Article")) {
+            $text = "Article " . $args{Object}->id;
+        }
     }
     return $text;
 }

--- a/share/html/Articles/Elements/BeforeMessageBox
+++ b/share/html/Articles/Elements/BeforeMessageBox
@@ -67,7 +67,7 @@
 <td><select name="<% $name_prefix %>Articles-Include-Article-Named-Hotlist" onchange="this.form.submit()">
 <option value="" selected><&|/l&>-</&></option>
 % while (my $article = $hotlist->Next) {
-<option value="<% $article->Id %>"><%$article->Name|| loc('(no name)')%>: <%$article->Summary || ''%></option>
+<option value="<% $article->id %>"><%$article->Name|| loc('(no name)')%>: <%$article->Summary || ''%></option>
 % }
 </select>
 </td>
@@ -76,19 +76,19 @@
 % }
 % my %dedupe_articles;
 % while (my $article = $articles_content->Next) {
-%   $dedupe_articles{$article->Id}++;
+%   $dedupe_articles{$article->id}++;
 <tr>
 <td>&nbsp;</td>
 <td><%$article->Name|| loc('(no name)')%>: <%$article->Summary%></td>
-<td><input type="submit" name="<% $name_prefix %>Articles-Include-Article-<%$article->Id%>" value="Go" /></td>
+<td><input type="submit" name="<% $name_prefix %>Articles-Include-Article-<%$article->id%>" value="Go" /></td>
 </tr>
 % }
 % while (my $article = $articles_basics->Next) {
-%   next if $dedupe_articles{$article->Id};
+%   next if $dedupe_articles{$article->id};
 <tr>
 <td>&nbsp;</td>
 <td><%$article->Name || loc('(no name)')%>: <%$article->Summary || ''%></td>
-<td><input type="submit" name="<% $name_prefix %>Articles-Include-Article-<%$article->Id%>" value="Go" /></td>
+<td><input type="submit" name="<% $name_prefix %>Articles-Include-Article-<%$article->id%>" value="Go" /></td>
 </tr>
 % }
 % if ( @$topics ) {
@@ -163,7 +163,7 @@ if ( $ARGS{id} && $ARGS{id} ne 'new' ) {
             Field => substr($arg, length($name_prefix)),
             Value => $ARGS{$arg},
         );
-        if ($article->Id) {
+        if ($article->id) {
             $uri{"a:" . $article->id}++;
         }
     }

--- a/share/html/Articles/Elements/BeforeMessageBox
+++ b/share/html/Articles/Elements/BeforeMessageBox
@@ -154,7 +154,6 @@ if ( my $tmp = $ARGS{$name_prefix ."Articles-Include-Article"} ) {
 
 my %uri;
 if ( $ARGS{id} && $ARGS{id} ne 'new' ) {
-    $uri{$_}++ for split ' ', ($ARGS{$ARGS{'id'}.'-RefersTo'} || '');
 
     foreach my $arg (keys %ARGS) {
         next if $name_prefix && substr($arg, 0, length($name_prefix)) ne $name_prefix;

--- a/share/html/Articles/Elements/BeforeMessageBox
+++ b/share/html/Articles/Elements/BeforeMessageBox
@@ -164,7 +164,7 @@ if ( $ARGS{id} && $ARGS{id} ne 'new' ) {
             Value => $ARGS{$arg},
         );
         if ($article->Id) {
-            $uri{$article->URI}++;
+            $uri{"a:" . $article->id}++;
         }
     }
 }

--- a/t/articles/interface.t
+++ b/t/articles/interface.t
@@ -173,15 +173,15 @@ $m->follow_link_ok( { text => 'Modify'}, 'Article -> Modify' );
 $m->content_like(qr/Refers to/, "found links edit box");
 my $ticket_id = $ticket->Id;
 my $turi = "t:$ticket_id";
-my $article_uri = $article1->Id;
-my $a1uri = "a:$article_uri";
+my $article_id = $article1->Id;
+my $a1uri = "a:$article_id";
 $m->submit_form(form_name => 'EditArticle',
                 fields => { $article3->Id.'-RefersTo' => $turi,
                             'RefersTo-'.$article3->Id => $a1uri }
                 );
 
 $m->content_like(qr/Ticket.*$ticket_id/, "Ticket linkto was created");
-$m->content_like(qr/Article.*$article_uri/, "Article linkfrom was created");
+$m->content_like(qr/Article.*$article_id/, "Article linkfrom was created");
 }
 
 # Now try to extract an article from a link.

--- a/t/articles/interface.t
+++ b/t/articles/interface.t
@@ -173,14 +173,15 @@ $m->follow_link_ok( { text => 'Modify'}, 'Article -> Modify' );
 $m->content_like(qr/Refers to/, "found links edit box");
 my $ticket_id = $ticket->Id;
 my $turi = "t:$ticket_id";
-my $a1uri = 'a:'.$article1->Id;
+my $article_uri = $article1->Id;
+my $a1uri = "a:$article_uri";
 $m->submit_form(form_name => 'EditArticle',
                 fields => { $article3->Id.'-RefersTo' => $turi,
                             'RefersTo-'.$article3->Id => $a1uri }
                 );
 
 $m->content_like(qr/Ticket.*$ticket_id/, "Ticket linkto was created");
-$m->content_like(qr/URI.*$a1uri/, "Article linkfrom was created");
+$m->content_like(qr/Article.*$article_uri/, "Article linkfrom was created");
 }
 
 # Now try to extract an article from a link.


### PR DESCRIPTION
- The for split loop doesn't seem to do anything useful, so it was removed. This did not break any tests.
- Added support for outputting Article in the Record.pm::FormatLinks function.
- Use shorthand article linking(a:xx) instead of whole URI
- Lowercasing of all article->id calls, as it is the preferred way to access id according to Record.pm

All tests pass locally.