### PR TITLE
rt-test-dependencies should check for Locale::PO in CORE section

### DIFF
--- a/sbin/rt-test-dependencies.in
+++ b/sbin/rt-test-dependencies.in
@@ -161,6 +161,7 @@ List::MoreUtils
 Locale::Maketext 1.06
 Locale::Maketext::Fuzzy 0.11
 Locale::Maketext::Lexicon 0.32
+Locale::PO
 Log::Dispatch 2.30
 LWP::Simple
 Mail::Header 2.12
@@ -221,7 +222,6 @@ Email::Abstract
 File::Find
 File::Which
 HTML::Entities
-Locale::PO
 Log::Dispatch::Perl
 Mojo::DOM
 Plack::Middleware::Test::StashWarnings 0.08


### PR DESCRIPTION
Since commit 33fcc338b871aa95ac1d5db8da738a498ad49ef8, lib/RT/I18N/Extract.pm has required Locale::PO.  rt-test-dependencies (or, at least, the version in the stable, 4.2, 4.4 branches) doesn't check that Locale::PO is installed.  This patch moves Locale::PO from the DEVELOPER section to the CORE section.