### PR TITLE
Print raw transaction info on missing queues

### DIFF
--- a/lib/RT/Transaction.pm
+++ b/lib/RT/Transaction.pm
@@ -1213,7 +1213,11 @@ sub _CanonicalizeRoleName {
             my $q2 = RT::Queue->new( $self->CurrentUser );
             $q2->Load( $self->NewValue );
             return ("[_1] changed from [_2] to [_3]",
-                    $self->loc($self->Field), $q1->Name // '#'.$q1->id, $q2->Name // '#'.$q2->id); #loc()
+                    $self->loc($self->Field),
+                    $q1->id ? $q1->Name ? $q1->Name : '#'.$q1->id
+                            : $self->OldValue,
+                    $q2->id ? $q2->Name ? $q2->Name : '#'.$q1->id
+                            : $self->NewValue); #loc()
         }
 
         # Write the date/time change at local time:


### PR DESCRIPTION
This change adds printing of OldValue and NewValue for Queue changes when no Queue is found.

One use case occurs on partial migration of a database, where some queues are not migrated. The transactions for the changes in the ticket history will only print # for queues not migrated, while this change will print the actual value of OldValue and/or NewValue.