### PR TITLE
Apply TransactionBatch at end of top ->Atomic call

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -1783,8 +1783,8 @@ sub Atomic {
     }
 
     if ($RT::Handle->TransactionDepth == $depth) {
-        $self->ApplyTransactionBatch;
         $RT::Handle->Commit;
+        $self->ApplyTransactionBatch if ( $depth == 0 );
     }
 
     return $context ? @ret : $ret[0];


### PR DESCRIPTION
8862bd94d introduced a regression, seen at least when calling
Ticket/Display.html?id=X&Action=YYY&Status=ZZZ. TransactionBatch scrips
are triggered for Owner change (Take here) but not for Status change.

All changes are wrapped inside an Atomic call. Action args is processed
first and trigger a $TicketObj->Take which calls ->SetOwner. This last
one wrap itself inside another Atomic call.

In ->Atomic, the first commited transaction trigger application of
TransactionBatch which itself forbid further execution through
->RanTransactionBatch flag.

This commit apply TransactionBatch only after end of all transactions.

It is also executed after txn commit to be consistent for all
transactions such as nested ones (which was old behaviour).