### PR TITLE
Set default search operator as "is" when CF is of type "Select"

### DIFF
--- a/share/html/Elements/SelectCustomFieldOperator
+++ b/share/html/Elements/SelectCustomFieldOperator
@@ -56,9 +56,13 @@ selected="selected"
 % }
 </select>
 
+<%INIT>
+$Default ||=  '=' if ( $CustomField->Type =~ /Select/i);
+</%INIT>
 <%ARGS>
 $Name => undef
 @Options => ( loc('matches'), loc("doesn't match"), loc('is'), loc("isn't"), loc('less than'), loc('greater than'))
 @Values => ('LIKE', 'NOT LIKE', '=', '!=', '<', '>')
 $Default => ''
+$CustomField => undef
 </%ARGS>

--- a/share/html/Search/Elements/PickCFs
+++ b/share/html/Search/Elements/PickCFs
@@ -83,6 +83,7 @@ while ( my $CustomField = $CustomFields->Next ) {
                            False => loc("isn't"),
                            TrueVal=> '=',
                            FalseVal => '!=',
+                           CustomField => $CustomField,
                          },
         };
     }


### PR DESCRIPTION
Having LIKE by default may result to more results than expected when you "select" a named value in search builder.