### PR TITLE
Filter out duplicate values in CF type select search

### DIFF
--- a/share/html/Elements/SelectCustomFieldValue
+++ b/share/html/Elements/SelectCustomFieldValue
@@ -52,7 +52,13 @@
 <select name="<%$Name%>">
 <option value="" selected="selected">-</option>
 <option value="NULL"><&|/l&>(no value)</&></option>
+% my %seen;
 % while (my $value = $values->Next) {
+% if ( $seen{$value->Name} ) {
+%     next;
+% } else {
+%     $seen{$value->Name} = 1;
+% }
 <option value="<%$value->Name%>"<% ($value->Name eq $Default) ? q[ selected="selected"] : ''%>><%$value->Name%></option>
 % }
 </select>


### PR DESCRIPTION
When a select is based on another with categories, multiple identical values
may appears in search builder because categories aren't used here.
But search is done against the customfield value "Name", not id, hence having
each Name once is enough.