### PR TITLE
Run Batch scrips once when a correspondence is mixed with a CF change

### DIFF
--- a/share/html/Ticket/Display.html
+++ b/share/html/Ticket/Display.html
@@ -191,7 +191,7 @@ if ($ARGS{'id'} eq 'new') {
         push @Actions, ProcessTicketBasics(  ARGSRef => \%ARGS, TicketObj => $TicketObj );
         push @Actions, ProcessTicketLinks(   ARGSRef => \%ARGS, TicketObj => $TicketObj );
         push @Actions, ProcessTicketDates(   ARGSRef => \%ARGS, TicketObj => $TicketObj );
-        push @Actions, ProcessObjectCustomFieldUpdates(ARGSRef => \%ARGS, TicketObj => $TicketObj );
+        push @Actions, ProcessObjectCustomFieldUpdates(ARGSRef => \%ARGS, Object => $TicketObj );
         push @Actions, ProcessTicketReminders( ARGSRef => \%ARGS, TicketObj => $TicketObj );
     });
     if ( !$SkipProcessing ) {

--- a/share/html/Ticket/ModifyLinks.html
+++ b/share/html/Ticket/ModifyLinks.html
@@ -76,7 +76,7 @@ my @results;
 $Ticket->Atomic(sub{
     $m->callback( TicketObj => $Ticket, ARGSRef => \%ARGS, Results => \@results );
     push @results, ProcessTicketLinks( TicketObj => $Ticket, ARGSRef => \%ARGS );
-    push @results, ProcessObjectCustomFieldUpdates( TicketObj => $Ticket, ARGSRef => \%ARGS );
+    push @results, ProcessObjectCustomFieldUpdates( Object => $Ticket, ARGSRef => \%ARGS );
 });
 
 MaybeRedirectForResults(

--- a/share/html/Ticket/ModifyPeople.html
+++ b/share/html/Ticket/ModifyPeople.html
@@ -109,7 +109,7 @@ unless ($OnlySearchForPeople or $OnlySearchForGroup) {
     $Ticket->Atomic(sub{
         push @results, ProcessTicketBasics( TicketObj => $Ticket, ARGSRef => \%ARGS);
         push @results, ProcessTicketWatchers( TicketObj => $Ticket, ARGSRef => \%ARGS);
-        push @results, ProcessObjectCustomFieldUpdates( TicketObj => $Ticket, ARGSRef => \%ARGS );
+        push @results, ProcessObjectCustomFieldUpdates( Object => $Ticket, ARGSRef => \%ARGS );
     });
 }
 

--- a/share/html/m/ticket/show
+++ b/share/html/m/ticket/show
@@ -106,7 +106,7 @@ if ($ARGS{'id'} eq 'new') {
         push @Actions, ProcessTicketBasics(  ARGSRef => \%ARGS, TicketObj => $Ticket );
         push @Actions, ProcessTicketLinks(   ARGSRef => \%ARGS, TicketObj => $Ticket );
         push @Actions, ProcessTicketDates(   ARGSRef => \%ARGS, TicketObj => $Ticket );
-        push @Actions, ProcessObjectCustomFieldUpdates(ARGSRef => \%ARGS, TicketObj => $Ticket );
+        push @Actions, ProcessObjectCustomFieldUpdates(ARGSRef => \%ARGS, Object => $Ticket );
         push @Actions, ProcessTicketReminders( ARGSRef => \%ARGS, TicketObj => $Ticket );
     });
 


### PR DESCRIPTION
On the Web UI, a response or comment on a ticket with a CF change at
the same times, makes TransactionBatch scrips run for the message/basic
fields transactions and another run for custom fields changes.

In Update.html, TicketObj was given to ProcessObjectCustomFieldUpdates
as $args{TicketObj} when this method works on $args{Object}. Without
Object, the method loads the ticket using the id present in customfields
ARGSRef, leading to a different object than the current batch one.