### PR TITLE
Do not check lifecycle when closing/opening a reminder

### DIFF
--- a/lib/RT/Reminders.pm
+++ b/lib/RT/Reminders.pm
@@ -160,7 +160,7 @@ sub Open {
     my $reminder = shift;
 
     my ( $status, $msg ) =
-      $reminder->SetStatus( $reminder->LifecycleObj->ReminderStatusOnOpen );
+      $reminder->_SetStatus( Status => $reminder->LifecycleObj->ReminderStatusOnOpen );
     $self->TicketObj->_NewTransaction(
         Type => 'OpenReminder',
         Field => 'RT::Ticket',
@@ -173,7 +173,7 @@ sub Resolve {
     my $self = shift;
     my $reminder = shift;
     my ( $status, $msg ) =
-      $reminder->SetStatus( $reminder->LifecycleObj->ReminderStatusOnResolve );
+      $reminder->_SetStatus( Status => $reminder->LifecycleObj->ReminderStatusOnResolve );
     $self->TicketObj->_NewTransaction(
         Type => 'ResolveReminder',
         Field => 'RT::Ticket',


### PR DESCRIPTION
Reminder status needs to be one of active and one of inactive statuses, but
transitions are targeted to tickets usage, so may block uselessly reminder
transition here.