### PR TITLE
Fix wrong numbers (and crash) in charts when query uses QueueCF

### DIFF
--- a/lib/RT/SearchBuilder.pm
+++ b/lib/RT/SearchBuilder.pm
@@ -342,6 +342,7 @@ sub _JoinForLookupType {
 sub _JOINS_FOR_LOOKUP_TYPES {
     my $class = blessed($_[0]) || $_[0];
     state %JOINS;
+    $class = 'RT::Tickets' if ( $class eq 'RT::Report::Tickets'  );
     return $JOINS{$class} ||= {};
 }
 


### PR DESCRIPTION
RegisterCustomFieldJoin is tied to RT::Tickets, not RT::Report::Tickets

error: Couldn't parse query: We don't know how to join for LookupType
       RT::Queue at /srv/rt/rt/sbin/../lib/RT/SearchBuilder.pm line 366.

Stack:
  [/srv/rt/rt/sbin/../lib/RT/SearchBuilder.pm:366]
  [/srv/rt/rt/sbin/../lib/RT/SearchBuilder.pm:687]
  [/srv/rt/rt/sbin/../lib/RT/Tickets.pm:1236]
  [/srv/rt/rt/sbin/../lib/RT/Tickets.pm:3131]
  [/usr/share/perl5/vendor_perl/Tree/Simple.pm:441]
  [/srv/rt/rt/sbin/../lib/RT/Tickets.pm:3141]
  [/srv/rt/rt/sbin/../lib/RT/Tickets.pm:3159]
  [/srv/rt/rt/sbin/../lib/RT/Report/Tickets.pm:470]
  [/srv/rt/rt/share/html/Search/Elements/Chart:59]
  [/srv/rt/rt/share/html/Search/Chart.html:129]
  [/srv/rt/rt/sbin/../lib/RT/Interface/Web.pm:696]
  [/srv/rt/rt/sbin/../lib/RT/Interface/Web.pm:375]
  [/srv/rt/rt/share/html/autohandler:53]