### PR TITLE
Add message level to logs to ease filtering

### DIFF
--- a/lib/RT.pm
+++ b/lib/RT.pm
@@ -298,9 +298,9 @@ sub InitLogging {
 
             $p{message} =~ s/(?:\r*\n)+$//;
             if ($p{level} eq 'debug') {
-                return "[$$] $p{message} ($filename:$line)\n";
+                return "[$$] $p{level}: $p{message} ($filename:$line)\n";
             } else {
-                return "[$$] $p{message}\n";
+                return "[$$] $p{level}: $p{message}\n";
             }
         };
 


### PR DESCRIPTION
Exemples:

Aug  9 10:16:31 localhost RT: [4413] warning: Case sensitive search by CustomFields.Name at /srv/rt/rt/local/html/Callbacks/FMLogistic/Elements/ShowCustomFields/MassageCustomFields line 3
Aug  9 10:16:33 localhost RT: [4413] debug: Rendering attachment #124370 of 'text/html' type (/srv/rt/rt/share/html/Elements/ShowTransactionAttachments:191)

