### PR TITLE
Set queue on the new empty ticket object

### DIFF
--- a/share/html/SelfService/Create.html
+++ b/share/html/SelfService/Create.html
@@ -94,7 +94,7 @@
     <td colspan="2">
         <& /Elements/EditCustomFields,
             %ARGS,
-            Object          => RT::Ticket->new($session{CurrentUser}),
+            Object          => $ticket,
             CustomFields    => $queue_obj->TicketCustomFields,
             AsTable         => 0,
             ForCreation     => 1,
@@ -122,6 +122,9 @@ $Queue => undef
 my @results;
 my $queue_obj = RT::Queue->new($session{'CurrentUser'});
 $queue_obj->Load($Queue);
+
+my $ticket = RT::Ticket->new($session{CurrentUser});
+$ticket->{_queue_obj} = $queue_obj;
 
 ProcessAttachments(ARGSRef => \%ARGS);
 

--- a/share/html/Ticket/Create.html
+++ b/share/html/Ticket/Create.html
@@ -449,6 +449,7 @@ $m->scomp( '/Articles/Elements/SubjectOverride', ARGSRef => \%ARGS, QueueObj => 
 $QueueObj->Disabled && Abort(loc("Cannot create tickets in a disabled queue."), Code => HTTP::Status::HTTP_NOT_FOUND);
 
 my $ticket = RT::Ticket->new($current_user); # empty ticket object
+$ticket->{_queue_obj} = $QueueObj;
 
 ProcessAttachments(ARGSRef => \%ARGS);
 


### PR DESCRIPTION
This allows some callbacks (custom field ones) to get access to the chosen
queue in the same way they do on an already created ticket.