### PR TITLE
ObjectCustomFieldValues try to guess the LargeContent encoding every time

### DIFF
--- a/lib/RT/ObjectCustomFieldValue.pm
+++ b/lib/RT/ObjectCustomFieldValue.pm
@@ -140,11 +140,17 @@ sub Create {
 
 sub LargeContent {
     my $self = shift;
-    return $self->_DecodeLOB(
-        $self->ContentType,
-        $self->ContentEncoding,
-        $self->_Value( 'LargeContent', decode_utf8 => 0 )
-    );
+    if (RT::I18N::IsTextualContentType($self->ContentType() // q{})) {
+        # It is assumed that the encoding is UTF-8, given it's hard-set in the constructor.
+        return $self->_Value( 'LargeContent', decode_utf8 => 1 );
+    }
+    else {
+        return $self->_DecodeLOB(
+            $self->ContentType,
+            $self->ContentEncoding,
+            $self->_Value( 'LargeContent', decode_utf8 => 0 )
+        );
+    }
 }
 
 


### PR DESCRIPTION
When accessing the `LargeValue` of an `ObjectCustomFieldValue`, it's encoding is guessed every time. This is problematic when a ticket has a large number of custom fields and/or when fields have many values (e.g., a ticket with hundreds of IPs in RTIR).

This encoding is automatically set to  `'utf-8'` on creation, and may be assumed that it's safe to just decode from _utf-8_, instead of analyzing its value and guessing the encoding (although that's useful for other contents such as comment bodies).

This patch changes this behavior so the encoding is only guessed when the `ObjectCustomFieldValue` content type is not textual (as determined by `RT::I18N::IsTextualContentType`)