### PR TITLE
Map numbers to themselves in %level_to_num

### DIFF
--- a/lib/RT.pm
+++ b/lib/RT.pm
@@ -237,7 +237,7 @@ sub InitLogging {
     use Log::Dispatch 1.6;
 
     my %level_to_num = (
-        map( { $_ => } 0..7 ),
+        map( { $_ => $_ } 0..7 ),
         debug     => 0,
         info      => 1,
         notice    => 2,


### PR DESCRIPTION
Map numeric levels to themselves, rather than to the next level up.