### PR TITLE
Fix that search result tr classes are applied on NEWLINE in Row callback

### DIFF
--- a/share/html/Elements/CollectionAsTable/Row
+++ b/share/html/Elements/CollectionAsTable/Row
@@ -71,7 +71,7 @@ foreach my $column (@Format) {
         }
         $item = 0;
         $m->out( '</tr>' . "\n" );
-        $m->out(  '<tr class="'
+        $m->out(  '<tr class="' . $Classes . ' '
                 . ( $Warning ? 'warnline' : $i % 2 ? 'oddline' : 'evenline' )
                 . '" >'
                 . "\n" );


### PR DESCRIPTION
# Context

I'm writing an [extension](https://github.com/NETWAYS/rt-extension-searchresult) which highlights search result rows on specific conditions. This can be handled with using the `Row` callback and setting the `$Classes` reference, resulting in an additional CSS class for e.g. adding a background color.

Sample code:

```
$ vim html/Callbacks/RT-Extension-SearchResult/Elements/CollectionList/EachRow
...
my $BGColorClass = $Record->getHighlight("rowclass");

if (defined($BGColorClass)) {
  push @additionalClasses, $BGColorClass;
}

$$Classes = join(' ', @additionalClasses);
```

## Version

RT 4.4.3 4df308e1e 

# Problem

This works for the first line. When the search result is split up with `NEWLINE` in between, the secondary `list-item` is printed without the overridden class. 

```
http://192.168.56.10/Search/Results.html?Format=%27%3Cb%3E%3Ca%20href%3D%22__WebPath__%2FTicket%2FDisplay.html%3Fid%3D__id__%22%3E__id__%3C%2Fa%3E%3C%2Fb%3E%2FTITLE%3A%23%27%2C%0A%27%3Cb%3E%3Ca%20href%3D%22__WebPath__%2FTicket%2FDisplay.html%3Fid%3D__id__%22%3E__Subject__%3C%2Fa%3E%3C%2Fb%3E%2FTITLE%3ASubject%27%2C%0AStatus%2C%0AQueueName%2C%0AOwner%2C%0APriority%2C%0A%27__NEWLINE__%27%2C%0A%27__NBSP__%27%2C%0A%27%3Csmall%3E__Requestors__%3C%2Fsmall%3E%27%2C%0A%27%3Csmall%3E__CreatedRelative__%3C%2Fsmall%3E%27%2C%0A%27%3Csmall%3E__ToldRelative__%3C%2Fsmall%3E%27%2C%0A%27%3Csmall%3E__LastUpdatedRelative__%3C%2Fsmall%3E%27%2C%0A%27%3Csmall%3E__TimeLeft__%3C%2Fsmall%3E%27%2C%0A%27__Icon__%27%2C%0A%27__LastUpdatedBy__%27&Order=DESC%7CASC%7CASC%7CASC&OrderBy=LastUpdated%7C%7C%7C&Query=Status%20!%3D%20%27resolved%27&RowsPerPage=50&SavedChartSearchId=new&SavedSearchId=RT%3A%3AUser-14-SavedSearch-13
```

![screen shot 2018-11-23 at 14 10 28](https://user-images.githubusercontent.com/382049/48945190-b8ec6d80-ef29-11e8-93ab-d4157559dca6.png)


# Fix

Add the `Classes` variable into the condition for newlines too.

![screen shot 2018-11-23 at 14 11 23](https://user-images.githubusercontent.com/382049/48945211-cace1080-ef29-11e8-9170-63213401d9b5.png)
