### PR TITLE
bin/rt should print password prompt to STDERR

### DIFF
--- a/bin/rt.in
+++ b/bin/rt.in
@@ -1059,14 +1059,14 @@ sub submit {
         die "GSSAPI support not available; failed to load perl module LWP::Authen::Negotiate:\n$@\n"
             unless eval { require LWP::Authen::Negotiate; 1 };
     } elsif ($config{auth} eq "basic") {
-        print "   Password will be sent to $server $how\n",
-              "   Press CTRL-C now if you do not want to continue\n"
-            if ! $config{passwd};
+        print STDERR "   Password will be sent to $server $how\n",
+                     "   Press CTRL-C now if you do not want to continue\n"
+                     if ! $config{passwd};
         $h->authorization_basic($config{user}, $config{passwd} || read_passwd() );
     } elsif ( !defined $session->cookie ) {
-        print "   Password will be sent to $server $how\n",
-              "   Press CTRL-C now if you do not want to continue\n"
-            if ! $config{passwd};
+        print STDERR "   Password will be sent to $server $how\n",
+                     "   Press CTRL-C now if you do not want to continue\n"
+                     if ! $config{passwd};
         push @$data, ( user => $config{user} );
         push @$data, ( pass => $config{passwd} || read_passwd() );
     }
@@ -1498,11 +1498,11 @@ sub read_passwd {
         die "No password specified (and Term::ReadKey not installed).\n";
     }
 
-    print "Password: ";
+    print STDERR "Password: ";
     Term::ReadKey::ReadMode('noecho');
     chomp(my $passwd = Term::ReadKey::ReadLine(0));
     Term::ReadKey::ReadMode('restore');
-    print "\n";
+    print STDERR "\n";
 
     return $passwd;
 }


### PR DESCRIPTION
Ticket #34216: Feature request: bin/rt should print password prompt
to STDERR

I've been using bin/rt in shell scripts, redirecting STDOUT to a file,
or piping it to other processes. This will hang, waiting for a password
prompt, if I haven't previously logged into rt.

Printing the password prompt to STDERR rather than STDOUT will send the
password prompt to the screen, even if STDOUT is redirected, and also
has the advantage of not polluting STDOUT with the password prompt.

This patch will cause the password prompt (as well as the 'Press CTRL-C
if you do not want to continue' warning) to print to STDERR rather
than STDOUT.