### PR TITLE
Fix table wrapping error in Ticket/Update.html

### DIFF
--- a/share/html/Ticket/Update.html
+++ b/share/html/Ticket/Update.html
@@ -119,7 +119,7 @@
 
 % $m->callback( %ARGS, CallbackName => 'AfterWorked', Ticket => $TicketObj );
 
-<& /Ticket/Elements/EditTransactionCustomFields, %ARGS, TicketObj => $TicketObj, AsTable => 1 &>
+<& /Ticket/Elements/EditTransactionCustomFields, %ARGS, TicketObj => $TicketObj, InTable => 1 &>
 
   </table>
   </&>


### PR DESCRIPTION
Commit 3b48f214f5a3d changed the component parameter from InTable to
AsTable for calling /Ticket/Elements/EditTransactionCustomFields.
Omitting InTable causes the called component to insert an unnecessary
(and wrong) wrapping <table> element to the already existing table.
The wrapping <table> element breaks the HTML validity.