### PR TITLE
Fix trouble with udefined Lifecycle type

### DIFF
--- a/share/html/Elements/SelectStatus
+++ b/share/html/Elements/SelectStatus
@@ -131,7 +131,7 @@ my $group_by_lifecycle = keys %statuses_by_lifecycle > 1;
 </%INIT>
 <%ARGS>
 $Name => undef
-$Type => undef,
+$Type => "ticket",
 
 @Statuses => ()
 $Object => undef,


### PR DESCRIPTION
I was getting a problem on my system with calls to `Lifecycle->Load` having a undefined type value, which caused the ticket page not to load. I tracked the problem down to this file. Everywhere else seems to give `Type` a default value of "ticket", except for this element. I changed this on my system and was able to get pages to load again.

Granted, this error showed up after progressively upgrading the system from 4.4.1 to 4.4.4, so if no one else has trouble with this, then this change could probably be ignored.