### PR TITLE
Allow login with any field from attr_match_list

### DIFF
--- a/lib/RT/Authen/ExternalAuth.pm
+++ b/lib/RT/Authen/ExternalAuth.pm
@@ -661,6 +661,9 @@ sub UserExists {
     } elsif ($config->{'type'} eq 'ldap') {
         $success = RT::Authen::ExternalAuth::LDAP::UserExists($username,$service);
     }
+    if ($success) {
+        $_[0] = $username;
+    }
 
     return $success;
 }


### PR DESCRIPTION
The current implementation of external users does not allow users to use multiple attributes (e.g. uid and email address) to logon to RT. With this simple modification any attribute could be used to identify a user as long as it results in an unique identification.
 
The UserExists method now searches in the LDAP directory for a match in any of the fields specified with attr_match_list. After an unique match is found (e.g. uid or email address) the provided username is updated to always reflect the value of the "Name" field. Now a user can use any element specified in attr_match_list to logon as long as the provided login data results in an unique result.

I'm not sure if you approve of by-ref-changing of method parameters. An alternative approach would be to rewrite UserExists so it returns the actual username as a string after looking for a match in LDAP or in a database or an empty string if no (unique) match is found.