### PR TITLE
Add username to SQL statment log

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -1303,7 +1303,9 @@ sub LogRecordedSQLStatements {
         }
         $RT::Logger->log(
             level   => $log_sql_statements,
-            message => "SQL("
+             message => $HTML::Mason::Commands::session{'CurrentUser'}->Name
+                . " - "
+                . "SQL("
                 . sprintf( "%.6f", $duration )
                 . "s): $sql;"
                 . ( @bind ? "  [ bound values: @{[map{ defined $_ ? qq|'$_'| : 'undef'} @bind]} ]" : "" )


### PR DESCRIPTION
Added the name of the user to the his corresponding SQL statements. Proofed to be useful for debugging as well as analyzing perfomance issues.