### PR TITLE
support multi-word CustomRole names in Notify Action

### DIFF
--- a/lib/RT/Action/Notify.pm
+++ b/lib/RT/Action/Notify.pm
@@ -113,7 +113,7 @@ sub SetRecipients {
                            # then RT::CustomRole-# or a role name
                            (?:
                                RT::CustomRole-(\d+)    # $2 role id
-                             | ( \w+ )                 # $3 role name
+                             | ( (?: \w\s?)+ )         # $3 role name
                            )
 
                            # then, optionally, a type after a slash


### PR DESCRIPTION
Currently we can create a CustomRole with names that include spaces, e.g. `Queue Manager`.

However, the `Notify.pm` Action only supports CustomRole names that match the regex `( \w+)`, i.e. a single word.

This pull request modifies the regex to allow for multiple words in the CustomRole name.