### PR TITLE
Revert "Notify the owner on common mis-configurations"

### DIFF
--- a/lib/RT/Interface/Email/Authz/Default.pm
+++ b/lib/RT/Interface/Email/Authz/Default.pm
@@ -93,16 +93,6 @@ sub CheckACL {
         elsif ( $args{'Action'} =~ /^correspond$/i ) {
             return 1 if $principal->HasRight( Object => $args{'Ticket'}, Right  => 'ReplyToTicket' );
             $msg = "$email has no right to reply to ticket $tid in queue $qname";
-
-            # Also notify the owner
-            MailError(
-                To          => RT->Config->Get('OwnerEmail'),
-                Subject     => "Failed attempt to reply to a ticket by email, from $email",
-                Explanation => <<EOT,
-$email attempted to reply to a ticket via email in the queue $qname; you
-might need to grant 'Everyone' the ReplyToTicket right.
-EOT
-            );
         }
         else {
             $RT::Logger->warning("Action '". ($args{'Action'}||'') ."' is unknown");
@@ -114,16 +104,6 @@ EOT
     elsif ( $args{'Action'} =~ /^(comment|correspond)$/i ) {
         return 1 if $principal->HasRight( Object => $args{'Queue'}, Right  => 'CreateTicket' );
         $msg = "$email has no right to create tickets in queue $qname";
-
-        # Also notify the owner
-        MailError(
-            To          => RT->Config->Get('OwnerEmail'),
-            Subject     => "Failed attempt to create a ticket by email, from $email",
-            Explanation => <<EOT,
-$email attempted to create a ticket via email in the queue $qname; you
-might need to grant 'Everyone' the CreateTicket right.
-EOT
-        );
     }
     else {
         $RT::Logger->warning("Action '". ($args{'Action'}||'') ."' is unknown with no ticket");

--- a/t/mail/gateway.t
+++ b/t/mail/gateway.t
@@ -194,7 +194,6 @@ EOF
     $u->Load("doesnotexist\@@{[RT->Config->Get('rtname')]}");
     ok( $u->Id, "user was created by failed ticket submission");
 
-    $m->next_warning_like(qr/Failed attempt to create a ticket by email, from doesnotexist\@\S+.*grant.*CreateTicket right/s);
     $m->next_warning_like(qr/Permission Denied: doesnotexist\@\S+ has no right to create tickets in queue General/);
     $m->no_leftover_warnings_ok;
 }
@@ -253,7 +252,6 @@ EOF
     my $u = RT::User->new(RT->SystemUser);
     $u->Load('doesnotexist-2@'.RT->Config->Get('rtname'));
     ok( $u->Id, "user was created by ticket correspondence submission");
-    $m->next_warning_like(qr/Failed attempt to reply to a ticket by email, from doesnotexist-2\@\S+.*grant.*ReplyToTicket right/s);
     $m->next_warning_like(qr/Permission Denied: doesnotexist-2\@\S+ has no right to reply to ticket $ticket_id in queue General/);
     $m->no_leftover_warnings_ok;
 }


### PR DESCRIPTION
This causes unneeded spam to the owner when we block access to a user
through the web interface.

This reverts commit 03d0af9a7dfe03ce0f2f86f831bcfe19bb29f5a9.