### PR TITLE
Leave umask flag

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -149,6 +149,21 @@ Set( @StaticRoots, () );
 
 =back
 
+=item C<$LeaveUMask>
+
+Set C<$LeaveUMask> to 1 to tell the Plack runner to preserve the umask
+of the running process.  By default, Plack will set the umask to 0,
+essentially making the socket file world-writeable.  
+
+This setting only applies if you are using FastCGI on UNIX domain 
+sockets.
+
+=cut
+
+Set( @$LeaveUMask, 0 );
+
+=back
+
 
 
 

--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -153,10 +153,11 @@ Set( @StaticRoots, () );
 
 Set C<$LeaveUMask> to 1 to tell the Plack runner to preserve the umask
 of the running process.  By default, Plack will set the umask to 0,
-essentially making the socket file world-writeable.  
+essentially making the socket file world-writeable.
 
 This setting only applies if you are using FastCGI on UNIX domain 
-sockets.
+sockets.  Be sure to set the umask to one that will allow your webserver 
+to communicate with RT via the unix domain socket.
 
 =cut
 

--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -153,7 +153,7 @@ Set( @StaticRoots, () );
 
 Set C<$LeaveUMask> to 1 to tell the Plack runner to preserve the umask
 of the running process.  By default, Plack will set the umask to 0,
-essentially making the socket file world-writeable.
+essentially making the socket file world-writable.
 
 This setting only applies if you are using FastCGI on UNIX domain 
 sockets.  Be sure to set the umask to one that will allow your webserver 

--- a/lib/RT/PlackRunner.pm
+++ b/lib/RT/PlackRunner.pm
@@ -77,6 +77,7 @@ sub parse_options {
 
     if ($self->{server} eq "FCGI") {
         # We deal with the possible failure modes of this in ->run
+        $self->set_options(leave_umask => int(RT->Config->Get('LeaveUMask')));
     } elsif ($args{port}) {
         $self->{explicit_port} = 1;
         my $old_app = $self->{app};


### PR DESCRIPTION
I was guiding someone on setting up a web based application using OpenBSD's httpd when I noticed that the unix domain socket RT was using for httpd to communicate via FastCGI was world-writable.  I didn't think this was very secure and looked into why it was doing that, since I hadn't explicitly told RT to do that.  I finally tracked it down to an option sent to Plack's FCGI handler that told the handler whether to set the umask to 0 (effectively make the file world-writable) or use the already available umask.

It turned out to be very simple to pass this flag through to Plack's FCGI handler.  I added some documentation to the RT-Config.pm.in file to make clear what was going on and that you should ensure you have the right umask that would allow the web server to communicate with RT.