### PR TITLE
bugfix: Correctly assign both return values of $Ticket->CurrentUserCanSetOwner()

### DIFF
--- a/share/html/Elements/Tabs
+++ b/share/html/Elements/Tabs
@@ -756,7 +756,8 @@ my $build_main_nav = sub {
                 my $actions = PageMenu()->child( actions => title => loc('Actions'), sort_order  => 95 );
 
                 my %can = %{ $obj->CurrentUser->PrincipalObj->HasRights( Object => $obj ) };
-                $can{'_ModifyOwner'} = $obj->CurrentUserCanSetOwner();
+                my $msg;
+                ( $can{'_ModifyOwner'}, $msg ) = $obj->CurrentUserCanSetOwner();
                 my $can = sub {
                     unless ($_[0] eq 'ExecuteCode') {
                         return $can{$_[0]} || $can{'SuperUser'};

--- a/share/html/Ticket/Elements/ShowSummary
+++ b/share/html/Ticket/Elements/ShowSummary
@@ -109,7 +109,7 @@ $Attachments => undef
 <%INIT>
 my $can_modify = $Ticket->CurrentUserHasRight('ModifyTicket');
 my $can_modify_cf = $Ticket->CurrentUserHasRight('ModifyCustomField');
-my $can_modify_owner = $Ticket->CurrentUserCanSetOwner();
+my ( $can_modify_owner, $msg ) = $Ticket->CurrentUserCanSetOwner();
 my $can_modify_people = $Ticket->CurrentUserHasRight('Watch')
                      || $Ticket->CurrentUserHasRight('WatchAsAdminCc');
 </%INIT>


### PR DESCRIPTION
This applies to share/html/Elements/Tabs and share/html/Ticket/Elements/ShowSummary.

This fixes a bug in the ticket menu tab for users without rights to set the current ticket owner: the People tab will no longer be shown in that case.

Similarly, the 'People' tab under 'Ticket Metadata' on the ticket summary page will no longer be clickable in that case.

This bug was introduced in commit 43f0e872019ca3abd20168730905477dac98785d