### PR TITLE
Attach css classes to ticket update cke editor

### DIFF
--- a/share/static/js/util.js
+++ b/share/static/js/util.js
@@ -730,7 +730,8 @@ jQuery(function() {
         jQuery(['action-response', 'action-private']).each(function(index, class_name) {
             jQuery('.' + class_name).on('DOMNodeInserted', 'iframe', function(e) {
                 setTimeout(function() {
-                    jQuery(e.target).contents().find('.cke_editable').addClass(class_name);
+                    var frame = jQuery(e.target).contents();
+                    frame.find('.cke_editable').addClass(class_name);
                 }, 100);
             });
         });


### PR DESCRIPTION
Found CSS classes for reply/comment were not attaching to cke editor body when using the dark theme. This caused the text color to be almost unreadable against the red/yellow background.