### PR TITLE
Allow for stdin input to rt shell action.

### DIFF
--- a/bin/rt.in
+++ b/bin/rt.in
@@ -176,6 +176,9 @@ exit handler();
 sub shell {
     $|=1;
     my $term = Term::ReadLine->new('RT CLI');
+    if ( not -t STDIN) {
+       $term->newTTY(*STDIN, *STDOUT);
+    }
     while ( defined ($_ = $term->readline($prompt)) ) {
         next if /^#/ || /^\s*$/;
 


### PR DESCRIPTION
This makes it possible to more easily script bulk operations for RT by allowing to read from STDIN instead of the tty when STDIN is NOT connected to a tty.

For example, this now works:
`rt ls -t user  -i | sed 's/user/show user/' | rt`
and is aproximately two times faster than
`rt ls -t user  -i | while read a;do rt show $a;done`