### PR TITLE
Do not remove WebPath from undefined result page

### DIFF
--- a/lib/RT/Interface/Web/MenuBuilder.pm
+++ b/lib/RT/Interface/Web/MenuBuilder.pm
@@ -700,11 +700,15 @@ sub BuildMainNav {
         }
         if ($has_query) {
             my $result_page = $HTML::Mason::Commands::DECODED_ARGS->{ResultPage};
-            if ( my $web_path = RT->Config->Get('WebPath') ) {
-                $result_page =~ s!^$web_path!!;
+            if ( $result_page ) {
+                if ( my $web_path = RT->Config->Get('WebPath') ) {
+                    $result_page =~ s!^$web_path!!;
+                }
+            }
+            else {
+                $result_page = '/Search/Results.html';
             }
 
-            $result_page ||= '/Search/Results.html';
             $current_search_menu->child( results => title => loc('Show Results'), path => "$result_page$args" );
         }
 


### PR DESCRIPTION
This commit fixes the bug reported in [I#37068](https://rt.bestpractical.com/Ticket/Display.html?id=37068). RT outputs the below warning when $WebPath is set in the configuration.

    Use of uninitialized value $result_page in substitution (s///) at lib/RT/Interface/Web/MenuBuilder.pm line 704.
