### PR TITLE
Priority class cleanup updates

### DIFF
--- a/share/html/Elements/RT__Ticket/ColumnMap
+++ b/share/html/Elements/RT__Ticket/ColumnMap
@@ -411,7 +411,8 @@ if ( RT->Config->Get('EnablePriorityAsString') ) {
 
         my $escaped     = $m->interp->apply_escapes( $string,      'h' );
         my $loc_escaped = $m->interp->apply_escapes( loc($string), 'h' );
-        return \( qq{<span class="ticket-info-$class-} . lc($escaped) . qq{">$loc_escaped</span>} );
+
+        return \( qq{<span class="ticket-info-$class-} . CSSClass(lc($escaped)) . qq{">$loc_escaped</span>} );
 
     };
     foreach my $field (qw(Priority InitialPriority FinalPriority)) {

--- a/share/html/Elements/SelectPriorityAsString
+++ b/share/html/Elements/SelectPriorityAsString
@@ -62,7 +62,7 @@
             ($value, $selected) = ($Default, 'selected="selected"');
         }
 </%PERL>
-    <option class="priority-<% lc $label %>" value="<% $value %>" <% $selected |n %>><% loc($label) %></option>
+    <option class="priority-<% CSSClass(lc $label) %>" value="<% $value %>" <% $selected |n %>><% loc($label) %></option>
 %   }
 %   if ( $group_by_name ) {
   </optgroup>

--- a/share/html/Ticket/Elements/ShowPriority
+++ b/share/html/Ticket/Elements/ShowPriority
@@ -50,8 +50,8 @@
 % } else {
 % my $current = $Ticket->PriorityAsString || '';
 % my $final = $Ticket->FinalPriorityAsString || '';
-<span class="Priority ticket-info-priority-<% $CSSClass->(lc($current)) %>"><% loc($current) %></span>/\
-<span class="FinalPriority ticket-info-final-priority-<% $CSSClass->(lc($final)) %>"><% loc($final) %></span>
+<span class="Priority ticket-info-priority-<% CSSClass(lc($current)) %>"><% loc($current) %></span>/\
+<span class="FinalPriority ticket-info-final-priority-<% CSSClass(lc($final)) %>"><% loc($final) %></span>
 % }
 <%ARGS>
 $Ticket => undef
@@ -66,10 +66,4 @@ if ( RT->Config->Get('EnablePriorityAsString') ) {
     $use_numeric = 0 if exists $config{$queue_name} ? $config{$queue_name} : $config{Default};
 }
 
-my $CSSClass = sub {
-    my $value = shift;
-    return '' unless defined $value;
-    $value =~ s/[^A-Za-z0-9_-]/_/g;
-    return $value;
-};
 </%INIT>


### PR DESCRIPTION
When PriorityAsString was shipped as an RT extension it was needed to duplicate the CSSClass method to be compatible with RT 4.0. It's no longer needed now that it has been cored in RT 5.
Also there was two places where clean up of spaces/non-ascii chars was missing.