### PR TITLE
take LDAPCreatePrivileged into account user update

### DIFF
--- a/lib/RT/LDAPImport.pm
+++ b/lib/RT/LDAPImport.pm
@@ -866,6 +866,7 @@ sub create_rt_user {
 
     if ($user_obj->Id) {
         my $message = "User $user->{Name} already exists as ".$user_obj->Id;
+        $user->{Privileged} = $RT::LDAPCreatePrivileged ? 1 : 0;
         if ($RT::LDAPUpdateUsers || $RT::LDAPUpdateOnly) {
             $RT::Logger->debug("$message, updating their data");
             if ($args{import}) {


### PR DESCRIPTION
Taking into account the value of LDAPCreatePrivileged when performing user updates in LDAP import. Please note that this might be far more complete and interesting: https://github.com/bestpractical/rt/pull/284