### PR TITLE
Update User.pm FriendlyFrom default

### DIFF
--- a/lib/RT/User.pm
+++ b/lib/RT/User.pm
@@ -1907,6 +1907,17 @@ Return the friendly name
 sub FriendlyName {
     my $self = shift;
     return $self->RealName if defined $self->RealName and length $self->RealName;
+    my $name = $self->Name;
+
+    my ($addr) = RT::EmailParser->ParseEmailAddress($name); 
+    if ($addr) {
+        if (my ($lhs,$domain) = split(/\@/, $addr)) {
+            # avoid problems with mimecast and similar, which frown on apparent forged addresses
+            return "$lhs (at) $domain" if (defined $lhs and defined $domain);
+        }
+    }
+
+    # use original version in worst case
     return $self->Name;
 }
 


### PR DESCRIPTION
This PR sets a better default for FriendlyFrom as some mail filter services (like mimecast) frown on apparently-forged From headers.  This makes sense as numerous MUA clients show only the comment as the sender.  I think it makes sense here but a case could be made to perform the transformation in RT::Action::SendEmail::SetFrom instead.