### PR TITLE
GROUPS was added to the list of reserved words in MySQL v8.0.2

### DIFF
--- a/etc/schema.mysql
+++ b/etc/schema.mysql
@@ -70,7 +70,7 @@ CREATE TABLE Principals (
 ) ENGINE=InnoDB CHARACTER SET utf8mb4;
 
 
-CREATE TABLE Groups (
+CREATE TABLE `Groups` (
   id INTEGER NOT NULL  AUTO_INCREMENT,
   Name varchar(200) NULL  ,
   Description varchar(255) NULL  ,
@@ -83,8 +83,8 @@ CREATE TABLE Groups (
   PRIMARY KEY (id)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4;
 
-CREATE INDEX Groups1 ON Groups (Domain, Name, Instance);
-CREATE INDEX Groups2 On Groups (Instance);
+CREATE INDEX Groups1 ON `Groups` (Domain, Name, Instance);
+CREATE INDEX Groups2 On `Groups` (Instance);
 
 CREATE TABLE ScripConditions (
   id INTEGER NOT NULL  AUTO_INCREMENT,


### PR DESCRIPTION
Backticks are necessary here to enable the reserved word to be treated as an identifier, otherwise installation fails at the point where the `Groups` table is created.

See https://dev.mysql.com/doc/refman/8.0/en/identifiers.html