### PR TITLE
Have rt-passwd exit with 0 on success

### DIFF
--- a/sbin/rt-passwd.in
+++ b/sbin/rt-passwd.in
@@ -105,7 +105,7 @@ die "Couldn't change password for user $username: $msg\n" unless $ret;
 
 print "Successfully changed password for user $username.\n";
 
-exit 1;
+exit 0;
 
 =head1 NAME
 


### PR DESCRIPTION
It is commonly expected that shell utilities return with a non-zero exitcode iff there was some error.

This PR makes `sbin/rt-passwd` exit with a zero exitcode iff no error was detected.