### PR TITLE
optionally skip tests when installing dependencies

### DIFF
--- a/sbin/rt-test-dependencies.in
+++ b/sbin/rt-test-dependencies.in
@@ -76,6 +76,8 @@ GetOptions(
     'siteinstall!',
     'help|h',
 
+    'testinstall!',
+
     # No-ops, for back-compat
     'v|verbose', 'with-ICAL', 'with-DASHBOARDS', 'with-USERLOGO',
 );
@@ -99,6 +101,7 @@ my %default = (
     'with-EXTERNALAUTH' => @RT_EXTERNALAUTH@,
     'with-S3'           => (uc(q{@ATTACHMENT_STORE@}) eq 'S3'),
     'with-DROPBOX'      => (uc(q{@ATTACHMENT_STORE@}) eq 'DROPBOX'),
+    'testinstall'       => 1
 );
 
 $default{"with-".uc("@DB_TYPE@")} = 1 unless grep {$args{"with-$_"}} qw/MYSQL PG SQLITE ORACLE/;
@@ -396,8 +399,13 @@ sub resolve_dep {
             if $args{siteinstall};
         local $CPAN::Config->{makepl_arg} = $installdirs;
 
-        my $rv = eval { require CPAN; CPAN::Shell->install($module) };
-        return $rv unless $@;
+	my $rv;
+	if ($args{'testinstall'}) {
+          $rv = eval { require CPAN; CPAN::Shell->install($module) };
+	} else {
+          $rv = eval { require CPAN; CPAN::Shell->notest('install', $module) };
+	}
+	return $rv unless $@;
     }
 
     if ( $ext =~ /\%s/ ) {


### PR DESCRIPTION
When installing dependencies with `sbin/rt-test-dependencies`, by default all installed dependencies are tested.  
This PR does not change the default behaviour.

This PR adds a flag to allow the user to opt-out of having the installed dependencies tested.  
This has proved necessary for our deployment; not alle dependencies document the additional dependencies/environment they require for their tests to pass.
Also, testing everything slowed down our automated installation considerably.