### PR TITLE
correctly resolve saved searches when importing dashboards

### DIFF
--- a/lib/RT/Handle.pm
+++ b/lib/RT/Handle.pm
@@ -2809,7 +2809,7 @@ sub _CanonilizeAttributeContent {
                     next unless $entry->{portlet_type} eq 'search';
                     if ( $entry->{ObjectType} && $entry->{ObjectId} && $entry->{Description} ) {
                         if ( my $object = $self->_LoadObject( $entry->{ObjectType}, $entry->{ObjectId} ) ) {
-                            my $attributes = $object->Attributes;
+                            my $attributes = $object->Attributes->Clone();
                             $attributes->Limit( FIELD => 'Description', VALUE => $entry->{Description} );
                             if ( my $attribute = $attributes->First ) {
                                 $entry->{id} = $attribute->id;


### PR DESCRIPTION
When resolving saved searches while creating dashboards from initialdata the same sql-query-object was reused.  
Therefore the resulting sql query accumulated limits (composed with `OR`), returning false positives to `…->First`.

Consider the following excerpt from our logs:
```
2021-10-25 14:48:32.645 UTC [4658] rt@rt5 LOG:  statement: SELECT main.* FROM Attributes main  WHERE (main.Description = '[_1] highest priority tickets I own') AND (main.ObjectId = 1) AND (main.ObjectType = 'RT::System')  ORDER BY main.id ASC 
2021-10-25 14:48:32.647 UTC [4658] rt@rt5 LOG:  statement: SELECT main.* FROM Attributes main  WHERE (main.Description = '[_1] highest priority tickets I own' OR main.Description = '[_1] newest unowned tickets') AND (main.ObjectId = 1) AND (main.ObjectType = 'RT::System')  ORDER BY main.id ASC 
2021-10-25 14:48:32.648 UTC [4658] rt@rt5 LOG:  statement: SELECT main.* FROM Attributes main  WHERE (main.Description = '[_1] highest priority tickets I own' OR main.Description = '[_1] newest unowned tickets' OR main.Description = 'Bookmarked Tickets') AND (main.ObjectId = 1) AND (main.ObjectType = 'RT::System')  ORDER BY main.id ASC 
```

The generated queries are obviously wrong.

The Problem lies with `sub Attributes {` in `lib/RT/Record.pm` memoizing the returned query object, causing the same object to be reused in every pass through the `for`-loop, accumulating limits as described above.
This PR `Clone()`s the query object in every pass through the `for`-loop, preventing this accumulation.