### PR TITLE
Add 'Description' and 'MergedTickets' fields

### DIFF
--- a/lib/RT/REST2/Resource.pm
+++ b/lib/RT/REST2/Resource.pm
@@ -110,6 +110,28 @@ sub expand_field {
 
             push @{ $result }, values %values if %values;
         }
+    } elsif ($field eq 'Description' && $item->isa('RT::Ticket')) {
+        my $transactions = $item->Transactions;
+        $transactions->Limit(
+            FIELD => 'Type',
+            VALUE => 'Create'
+        );
+        if ($transactions->Count > 0) {
+			my $forceHtml = $self->request->param('forceHtml');
+		    my $content = undef;
+			if (!defined $forceHtml || $forceHtml eq '1' || $forceHtml eq 'True') {
+				$content = $transactions->First->Content('Type' => 'text/html');
+			} else {
+				$content = $transactions->First->Content;
+			}
+            if (defined $content) {
+				$result = $content;
+            }
+        }
+    } elsif ($field eq 'MergedTickets' && $item->isa('RT::Ticket')) {
+        my $method = 'Merged';
+        my @obj = $item->$method;
+        $result = \@obj;
     } elsif ($field eq 'ContentLength' && $item->can('ContentLength')) {
         $result = $item->ContentLength;
     } elsif ($field eq 'CustomRoles') {


### PR DESCRIPTION
This PR adds two fields to the ticket search endpoint:

- **Description:** Content of the ticket first transaction;
- **MergedTickets:** List of the tickets merged into the current one.


Example:
`http://localhost/REST/2.0/tickets?query=Queue='general'&fields=Description,MergedTickets`

```json
{
  "pages": 1,
  "page": 1,
  "per_page": 20,
  "count": 1,
  "items": [
    {
      "id": "652",
      "Description": "<p>Ticket description text...</p>",
      "type": "ticket",
      "MergedTickets": [
        "650",
        "541"
      ],
      "_url": "http://localhos/REST/2.0/ticket/652"
    }
  ]
}
```