### PR TITLE
correctly handle logically empty simple searches (i.e. any)

### DIFF
--- a/share/html/Search/Results.html
+++ b/share/html/Search/Results.html
@@ -168,6 +168,7 @@ $session{'i'}++;
 $session{$session_name} = $Class->new($session{'CurrentUser'}) ;
 
 my ( $ok, $msg );
+$Query = "id > 0" if $Query eq "";
 if ( $Query ) {
     if ( $Class eq 'RT::Transactions' ) {
         my @limits = ( "ObjectType = '$ObjectType'", "($Query)" );


### PR DESCRIPTION
Our users expect that typing `any` in simple search returns a list of all tickets; this also conforms to the inline documentation for the simple search feature.

During parsing the query `any` is mapped to the empty string.
Thus all following "truthiness" checks treat the query as falsy, returning extremely unhelpful error messages instead of results.

This PR substitutes a default catch-all query iff the query is empty due to parsing.
A truely empty query is cought earlier.