### PR TITLE
Make setting sqldump actually work

### DIFF
--- a/sbin/rt-shredder.in
+++ b/sbin/rt-shredder.in
@@ -253,6 +253,7 @@ sub parse_args
     if( GetOptions( 'sqldump=s' => \$tmp ) && $tmp ) {
         $opt{'sqldump'} = $tmp;
     }
+    $tmp = undef;
 
     if( GetOptions( 'no-sqldump' => \$tmp ) && $tmp ) {
         $opt{'no-sqldump'} = $tmp;


### PR DESCRIPTION
If `--sqldump` is set then the filepath will end up in `$tmp`. The later call to `GetOptions( 'no-sqldump' => \$tmp )` will always succeed because it is a valid getopts specification (it just doesn't set anything). Then the `&& $tmp` condition will also pass because `$tmp` still has a value from when `--sqldump` earlier set it. The result is that `$opt{'no-sqldump'}` will end up being set to the filepath of the dump. Later on, this will seem like `--no-dump` was actually requested and no SQL dump will take place.

Fix this by unsetting `$tmp` before it is tested again.