### PR TITLE
Add Basics link option to Query Builder

### DIFF
--- a/share/html/Search/Elements/BuildFormatString
+++ b/share/html/Search/Elements/BuildFormatString
@@ -329,6 +329,10 @@ elsif ( $AddCol ) {
                     $column{Prefix} .= q{<a HREF="__WebPath__/Ticket/Update.html?Action=Comment&DefaultStatus=resolved&id=__id__">};
                     $column{Suffix} .= "</a>";
                 }
+                elsif ( $Link eq "Basics" ) {
+                    $column{Prefix} .= q{<a HREF="__WebPath__/Ticket/Modify.html?id=__id__">};
+                    $column{Suffix} .= "</a>";
+                }
             }
 
             if ($Title) {

--- a/share/html/Search/Elements/EditFormat
+++ b/share/html/Search/Elements/EditFormat
@@ -119,6 +119,7 @@ jQuery( function() {
               <option value="Respond"><&|/l&>Respond</&></option>
               <option value="Comment"><&|/l&>Comment</&></option>
               <option value="Resolve"><&|/l&>Resolve</&></option>
+              <option value="Basics"><&|/l&>Basics</&></option>
 % }
           </select>
         </div>


### PR DESCRIPTION
Add 'Basics' to the Format Link options menu under Display Columns in Query Builder.