### PR TITLE
ExtractSubjectTag Action: prepend, not append, remote system's subject tag

### DIFF
--- a/lib/RT/Action/ExtractSubjectTag.pm
+++ b/lib/RT/Action/ExtractSubjectTag.pm
@@ -122,7 +122,7 @@ sub Commit {
                 next TAGLIST;
             }
         }
-        $TicketSubject .= " $tag" unless ( $TicketSubject =~ /\Q$tag\E/ );
+        $TicketSubject = "$tag $TicketSubject" unless ( $TicketSubject =~ /\Q$tag\E/ );
     }
 
     $self->TicketObj->SetSubject($TicketSubject)


### PR DESCRIPTION
Too long (200+) ticket subjects (produced by this action) are shortened automatically.
This could cut off the remote system's subject tag if at the end.