### PR TITLE
Fix cf on transactions querybuilder

### DIFF
--- a/share/html/Elements/RT__Transaction/ColumnMap
+++ b/share/html/Elements/RT__Transaction/ColumnMap
@@ -55,7 +55,8 @@ my $get_ticket_value = sub {
     return sub { return $_[0]->ObjectType eq 'RT::Ticket' ? $sub->(@_) : '' };
 };
 
-my $COLUMN_MAP = {
+my ($COLUMN_MAP, $WCOLUMN_MAP);
+$WCOLUMN_MAP = $COLUMN_MAP = {
     ObjectType => {
         title     => 'Object Type', # loc
         attribute => 'ObjectType',
@@ -185,6 +186,53 @@ my $COLUMN_MAP = {
     TicketFinalPriority => {
         title     => 'Ticket FinalPriority', # loc
         value     => $get_ticket_value->( @_, sub { $_[0]->Object->FinalPriority } ),
+    },
+    TicketCustomFieldView => {
+        attribute => sub { return shift @_ },
+        title     => sub { return pop @_ },
+        value     => sub {
+            my $self = $WCOLUMN_MAP->{TicketCustomFieldView};
+            my $cf   = $self->{load}->(@_);
+            return unless $cf->Id;
+            return $self->{render}->( $cf, $cf->ValuesForObject($_[0]->Object)->ItemsArrayRef );
+        },
+        load      => sub {
+            # Cache the CF object on a per-request basis, to avoid
+            # having to load it for every row
+            my $key = join("-","CF",
+                           $_[0]->Object->CustomFieldLookupType,
+                           $_[0]->Object->CustomFieldLookupId,
+                           $_[-1]);
+
+            my $cf = $m->notes($key);
+            unless ($cf) {
+                $cf = $_[0]->Object->LoadCustomFieldByIdentifier($_[-1]);
+                RT->Logger->debug("Unable to load $_[-1] for ".$_[0]->Object->CustomFieldLookupType." ".$_[0]->Object->CustomFieldLookupId)
+                    unless $cf->Id;
+                $m->notes($key, $cf);
+            }
+            return $cf;
+        },
+        render    => sub {
+            my ($cf, $ocfvs) = @_;
+            my $comp = $m->comp_exists("/Elements/ShowCustomField".$cf->Type)
+                     ? "/Elements/ShowCustomField".$cf->Type
+                     : undef;
+
+            my @values = map {
+                $comp
+                    ? \($m->scomp( $comp, Object => $_ ))
+                    : $_->Content
+            } @$ocfvs;
+
+            if (@values > 1) {
+                for my $value (splice @values) {
+                    push @values, \"<li>", $value, \"</li> \n";
+                }
+                @values = (\"<ul class='cf-values'>", @values, \"</ul>");
+            }
+            return @values;
+        },
     },
 };
 

--- a/share/html/Search/Elements/BuildFormatString
+++ b/share/html/Search/Elements/BuildFormatString
@@ -93,8 +93,12 @@ if ( $Class eq 'RT::Transactions' ) {
         my $queue = RT::Queue->new( $session{'CurrentUser'} );
         $queue->Load($id);
         next unless $queue->Id;
-        $CustomFields->LimitToQueue( $queue->Id );
-        $CustomFields->SetContextObject($queue) if keys %queues == 1;
+        # Do not use ->LimitToQueue here because it hardcodes a LookupType of 'RT::Queue-RT::Ticket'
+        $CustomFields->Limit (ALIAS => $CustomFields->_OCFAlias,
+            ENTRYAGGREGATOR => 'OR',
+            FIELD => 'ObjectId',
+            VALUE => $queue->Id,
+        );
     }
     $CustomFields->Limit(
         ALIAS           => $CustomFields->_OCFAlias,

--- a/share/html/Search/Elements/BuildFormatString
+++ b/share/html/Search/Elements/BuildFormatString
@@ -112,6 +112,30 @@ if ( $Class eq 'RT::Transactions' ) {
         push @fields, "CustomField.{" . $CustomField->Name . "}";
         push @fields, "CustomFieldView.{" . $CustomField->Name . "}";
     }
+    my $TicketCustomFields = RT::CustomFields->new( $session{'CurrentUser'} );
+    foreach my $id ( keys %queues ) {
+
+        # Gotta load up the $queue object, since queues get stored by name now.
+        my $queue = RT::Queue->new( $session{'CurrentUser'} );
+        $queue->Load($id);
+        next unless $queue->Id;
+        $TicketCustomFields->Limit (ALIAS => $CustomFields->_OCFAlias,
+            ENTRYAGGREGATOR => 'OR',
+            FIELD => 'ObjectId',
+            VALUE => $queue->Id,
+        );
+    }
+    $TicketCustomFields->Limit(
+        ALIAS           => $TicketCustomFields->_OCFAlias,
+        ENTRYAGGREGATOR => 'OR',
+        FIELD           => 'ObjectId',
+        VALUE           => 0,
+    );
+    $TicketCustomFields->LimitToLookupType('RT::Queue-RT::Ticket');
+
+    while ( my $TicketCustomField = $TicketCustomFields->Next ) {
+        push @fields, "TicketCustomFieldView.{" . $TicketCustomField->Name . "}";
+    }
 }
 elsif ( $Class eq 'RT::Assets' ) {
     $Format ||= RT->Config->Get('AssetDefaultSearchResultFormat');


### PR DESCRIPTION
Format fields wrongly list queue or global ticket customfields as available in transactions query builder. Results produces then empty fields.

So first, list every Transaction customfields (global and depending on TicketQueue filter if any) which will be processed as usual (CustomField.{foo} means transaction CF "foo". 

Then add every ticket customfields  (also global and depending on TicketQueue filter if any) as available field.They are displayed using the transaction->Object and the syntax TicketCustomFieldView.{...}.