### PR TITLE
Keep the Owner when using SelectOwnerAutocomplete

### DIFF
--- a/share/html/Elements/SelectOwnerAutocomplete
+++ b/share/html/Elements/SelectOwnerAutocomplete
@@ -61,6 +61,8 @@ if ( $Default and not $Default =~ /\D/ ) {
     my $user = RT::User->new( $session{'CurrentUser'} );
     $user->Load($Default);
     $value = $user->$ValueAttribute;
+} elsif ( $Default ) {
+    $value = $Default;
 } elsif (defined $TicketObj) {
     $value = $TicketObj->OwnerObj->$ValueAttribute;
 }


### PR DESCRIPTION
When going through SelectOwnerAutocomplete, the load
of a template on investigation launch passes the selected
value in $Default as text, but SelectOwnerAutocomplete only
handles the field as a numeric id.
Just copying $Default to $value fixes the issue.