### PR TITLE
Do not check acl when auto-setting core date fields

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -2511,7 +2511,8 @@ sub _SetStatus {
         $self->_Set(
             Field             => 'Started',
             Value             => $now->ISO,
-            RecordTransaction => 0
+            RecordTransaction => 0,
+            CheckACL          => 0,
         );
     }
 
@@ -2522,6 +2523,7 @@ sub _SetStatus {
             Field             => 'Resolved',
             Value             => $now->ISO,
             RecordTransaction => 0,
+            CheckACL          => 0,
         );
     }
 


### PR DESCRIPTION
When using custom rights in lifecycles, a user with only a right such as
"CloseTicket" should trigger the update of "Resolved" field without
"ModifyTicket" right.