### PR TITLE
All commands should have the "RT CMD BOILERPLATE"

### DIFF
--- a/bin/rt-mailgate.in
+++ b/bin/rt-mailgate.in
@@ -55,6 +55,23 @@ rt-mailgate - Mail interface to RT.
 use strict;
 use warnings;
 
+# fix lib paths, some may be relative
+BEGIN { # BEGIN RT CMD BOILERPLATE
+    require File::Spec;
+    require Cwd;
+    my @libs = ("@RT_LIB_PATH@", "@LOCAL_LIB_PATH@");
+    my $bin_path;
+
+    for my $lib (@libs) {
+        unless ( File::Spec->file_name_is_absolute($lib) ) {
+            $bin_path ||= ( File::Spec->splitpath(Cwd::abs_path(__FILE__)) )[1];
+            $lib = File::Spec->catfile( $bin_path, File::Spec->updir, $lib );
+        }
+        unshift @INC, $lib;
+    }
+
+}
+
 use Getopt::Long;
 
 my $opts = { };

--- a/bin/rt.in
+++ b/bin/rt.in
@@ -52,6 +52,23 @@
 use strict;
 use warnings;
 
+# fix lib paths, some may be relative
+BEGIN { # BEGIN RT CMD BOILERPLATE
+    require File::Spec;
+    require Cwd;
+    my @libs = ("@RT_LIB_PATH@", "@LOCAL_LIB_PATH@");
+    my $bin_path;
+
+    for my $lib (@libs) {
+        unless ( File::Spec->file_name_is_absolute($lib) ) {
+            $bin_path ||= ( File::Spec->splitpath(Cwd::abs_path(__FILE__)) )[1];
+            $lib = File::Spec->catfile( $bin_path, File::Spec->updir, $lib );
+        }
+        unshift @INC, $lib;
+    }
+
+}
+
 if ( $ARGV[0] && $ARGV[0] =~ /^(?:--help|-h)$/ ) {
     require Pod::Usage;
     print Pod::Usage::pod2usage( { verbose => 2 } );


### PR DESCRIPTION
No idea why these two were missed, but rt-mailgate certainly breaks when
the system libwww-perl is out of date.