### PR TITLE
Update Condition.pm

### DIFF
--- a/lib/RT/Condition.pm
+++ b/lib/RT/Condition.pm
@@ -198,7 +198,7 @@ sub DESTROY {
 
     # We need to clean up all the references that might maybe get
     # oddly circular
-    $self->{'TemplateObj'} =undef
+    $self->{'TemplateObj'} = undef;
     $self->{'TicketObj'} = undef;
     $self->{'TransactionObj'} = undef;
     $self->{'ScripObj'} = undef;


### PR DESCRIPTION
Add missing semicolon.  Perl 5.36 won't load the module without it.

That in turn causes RT to silently (silently in the web UI, not-so-silently in the logs) refuse to send any emails after updating from Perl 5.34 to 5.36.