### PR TITLE
Rewind uploaded file after reading

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -4072,10 +4072,12 @@ sub _UploadedFile {
     my $filename = "$fh";
     $filename =~ s#^.*[\\/]##;
     binmode($fh);
+    my $content = do { local $/; scalar <$fh>; };
+    seek($fh, 0, 0);
 
     return {
         Value        => $filename,
-        LargeContent => do { local $/; scalar <$fh> },
+        LargeContent => $content,
         ContentType  => $upload_info->{'Content-Type'},
     };
 }


### PR DESCRIPTION
$fh is a ref to the filehandle given by cgi. Hence if this method is called
twice (it is if you installed RT::Extension::MandatoryOnTransition with
Upload/Image CF support[1]) the second reading will return empty data because
it starts at end of file.

[1] - https://github.com/bestpractical/rt-extension-mandatoryontransition/pull/6