### PR TITLE
Replace boilerplate HTML for rows in key-value lists with a standardized component

### DIFF
--- a/share/html/Elements/LabelValueRow
+++ b/share/html/Elements/LabelValueRow
@@ -1,0 +1,74 @@
+%# BEGIN BPS TAGGED BLOCK {{{
+%#
+%# COPYRIGHT:
+%#
+%# This software is Copyright (c) 1996-2022 Best Practical Solutions, LLC
+%#                                          <sales@bestpractical.com>
+%#
+%# (Except where explicitly superseded by other copyright notices)
+%#
+%#
+%# LICENSE:
+%#
+%# This work is made available to you under the terms of Version 2 of
+%# the GNU General Public License. A copy of that license should have
+%# been provided with this software, but in any event can be snarfed
+%# from www.gnu.org.
+%#
+%# This work is distributed in the hope that it will be useful, but
+%# WITHOUT ANY WARRANTY; without even the implied warranty of
+%# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%# General Public License for more details.
+%#
+%# You should have received a copy of the GNU General Public License
+%# along with this program; if not, write to the Free Software
+%# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+%# 02110-1301 or visit their web page on the internet at
+%# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
+%#
+%#
+%# CONTRIBUTION SUBMISSION POLICY:
+%#
+%# (The following paragraph is not intended to limit the rights granted
+%# to you to modify and distribute this software under the terms of
+%# the GNU General Public License and is only of importance to you if
+%# you choose to contribute your changes and enhancements to the
+%# community by submitting them to Best Practical Solutions, LLC.)
+%#
+%# By intentionally submitting any modifications, corrections or
+%# derivatives to this work, or any other work intended for use with
+%# Request Tracker, to Best Practical Solutions, LLC, you confirm that
+%# you are the copyright holder for those contributions and you grant
+%# Best Practical Solutions,  LLC a nonexclusive, worldwide, irrevocable,
+%# royalty-free, perpetual, license to use, copy, create derivative
+%# works based on those contributions, and sublicense and distribute
+%# those contributions and any derivatives thereof.
+%#
+%# END BPS TAGGED BLOCK }}}
+<%args>
+$class => undef
+$label => undef
+$value => undef
+$value_span_class => undef
+$raw_value => undef
+</%args>
+<%init>
+</%init>
+<div class="<% $class %> form-row">
+    <div class="label col-3"><% $label %>:</div>
+    <div class="value col-9">
+<%perl>
+     if ($value_span_class) {
+         $m->out('<span class="'.$m->interp->apply_escapes($value_span_class,"h").'">');
+     } 
+     if ($raw_value) {
+         $m->out($raw_value);
+     } else {
+         $m->out($m->interp->apply_escapes($value,"h"));
+     }
+     if ($value_span_class) {
+        $m->out('</span>');
+     } 
+</%perl>
+    </div>
+</div>

--- a/share/html/Ticket/Elements/ShowBasics
+++ b/share/html/Ticket/Elements/ShowBasics
@@ -46,76 +46,43 @@
 %#
 %# END BPS TAGGED BLOCK }}}
 <div>
-  <div class="id form-row">
-    <div class="label col-3"><&|/l&>Id</&>:</div>
-    <div class="value col-9"><span><%$Ticket->Id %></span></div>
-  </div>
-  <div class="status form-row">
-    <div class="label col-3"><&|/l&>Status</&>:</div>
-    <div class="value col-9"><span class="current-value"><% loc($Ticket->Status) %></span></div>
-  </div>
+  <& /Elements/LabelValueRow, class => 'id', label => loc("Id"), value => $Ticket->id &>
+  <& /Elements/LabelValueRow, class => 'status', label => loc("Status"), value => loc($Ticket->Status), value_span_class => "current-value" &>
 % if ( !$Ticket->QueueObj->SLADisabled ) {
-  <div class="sla form-row">
-    <div class="label col-3"><&|/l&>SLA</&>:</div>
-    <div class="value col-9"><span class="current-value"><% loc($Ticket->SLA) %></span></div>
-  </div>
+  <& /Elements/LabelValueRow, class => "sla", label => loc("SLA"), value=> loc($Ticket->SLA), value_span_class => "current_value" &>
 % }
 % if ($show_time_worked) {
 % if ($Ticket->TimeEstimated) {
-  <div class="time estimated form-row">
-    <div class="label col-3"><&|/l&>Estimated</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowTime, minutes => $Ticket->TimeEstimated &></span></div>
-  </div>
+  <& /Elements/LabelValueRow, class => "time estimated", label => loc("Estimated"), value_span_class => "current-value", raw_value => $m->scomp("ShowTime", minutes => $Ticket->TimeEstimated) &>
 % }
 % $m->callback( %ARGS, CallbackName => 'AfterTimeEstimated', TicketObj => $Ticket );
 % if ($Ticket->TimeWorked) {
-  <div class="time worked sum form-row">
-    <div class="label col-3"><&|/l&>Worked</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowTime, minutes => $Ticket->TimeWorked &></span></div>
-  </div>
+    <& /Elements/LabelValueRow, class => "time worked sum", label => loc("Worked"), value_span_class => "current-value", raw_value => $m->scomp("ShowTime", minutes => $Ticket->TimeWorked ) &>
 % }
 % my $totalTimeWorked = 0;
 % if (RT->Config->Get('DisplayTotalTimeWorked') && ($totalTimeWorked = $Ticket->TotalTimeWorked)) {
-  <div class="total time worked sum form-row">
-    <div class="label col-3"><&|/l&>Total Time Worked</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowTime, minutes => $totalTimeWorked &></span></div>
-  </div>
+    <& /Elements/LabelValueRow, class => "total time worked sum", label => loc("Total Time Worked"), value_span_class => "current-value", raw_value => $m->scomp("ShowTime", minutes => $totalTimeWorked ) &>
 % }
 % if ( keys %$time_worked ) {
-<div class="time worked by-user form-row">
-  <div class="label col-3"><&|/l&>Users</&>:</div>
-  <div class="value col-9">
-    <span class="current-value">
-%   for my $user ( keys %$time_worked ) {
-      <div>
-        <span class="value"><% $user %>:</span>
-        <span class="value"><& /Ticket/Elements/ShowTime, minutes => $time_worked->{$user} &></span>
-      </div>
-%   }
-    </span>
-  </div>
-</div>
+  <& /Elements/LabelValueRow, class => "time worked by-user", label => loc("Users"),
+  value_span_class => "current-value", raw_value => $m->scomp("ShowTimeWorkedByUser", time_worked => $time_worked) &>
 % }
 % $m->callback( %ARGS, CallbackName => 'AfterTimeWorked', TicketObj => $Ticket );
 % if ($Ticket->TimeLeft) {
-  <div class="time left form-row">
-    <div class="label col-3"><&|/l&>Left</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowTime, minutes => $Ticket->TimeLeft &></span></div>
-  </div>
+  <& /Elements/LabelValueRow, class => "time left",label => loc("Left"), value_span_class => "current-value", value => $m->scomp( "ShowTime", minutes => $Ticket->TimeLeft) &>
 % }
 % }
 % $m->callback( %ARGS, CallbackName => 'AfterTimeLeft', TicketObj => $Ticket );
-  <div class="priority form-row">
-    <div class="label col-3"><&|/l&>Priority</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowPriority, Ticket => $Ticket &></span></div>
-  </div>
+  <& /Elements/LabelValueRow, 
+  class => "priority",
+  label => loc("Priority"),
+  value_span_class => "current-value",
+  raw_value => $m->scomp("ShowPriority", Ticket => $Ticket )
+  &>
 % $m->callback( %ARGS, CallbackName => 'AfterPriority', TicketObj => $Ticket );
 %# This will check SeeQueue at the ticket role level, queue level, and global level
 % if ($Ticket->CurrentUserHasRight('SeeQueue')) {
-  <div class="queue form-row">
-    <div class="label col-3"><&|/l&>Queue</&>:</div>
-    <div class="value col-9"><span class="current-value"><& ShowQueue, Ticket => $Ticket, QueueObj => $Ticket->QueueObj &></span></div>
-  </div>
+  <& /Elements/LabelValueRow, class =>"queue", label => loc("Queue"), value_span_class => "current-value", raw_value => $m->scomp("ShowQueue", Ticket => $Ticket, QueueObj => $Ticket->QueueObj) &>
 % }
 % $m->callback( %ARGS, CallbackName => 'AfterQueue', TicketObj => $Ticket );
   <& /Ticket/Elements/ShowCustomFields, Ticket => $Ticket, Grouping => 'Basics', Table => 0 &>

--- a/share/html/Ticket/Elements/ShowTimeWorkedByUser
+++ b/share/html/Ticket/Elements/ShowTimeWorkedByUser
@@ -1,0 +1,56 @@
+%# BEGIN BPS TAGGED BLOCK {{{
+%#
+%# COPYRIGHT:
+%#
+%# This software is Copyright (c) 1996-2022 Best Practical Solutions, LLC
+%#                                          <sales@bestpractical.com>
+%#
+%# (Except where explicitly superseded by other copyright notices)
+%#
+%#
+%# LICENSE:
+%#
+%# This work is made available to you under the terms of Version 2 of
+%# the GNU General Public License. A copy of that license should have
+%# been provided with this software, but in any event can be snarfed
+%# from www.gnu.org.
+%#
+%# This work is distributed in the hope that it will be useful, but
+%# WITHOUT ANY WARRANTY; without even the implied warranty of
+%# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%# General Public License for more details.
+%#
+%# You should have received a copy of the GNU General Public License
+%# along with this program; if not, write to the Free Software
+%# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+%# 02110-1301 or visit their web page on the internet at
+%# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
+%#
+%#
+%# CONTRIBUTION SUBMISSION POLICY:
+%#
+%# (The following paragraph is not intended to limit the rights granted
+%# to you to modify and distribute this software under the terms of
+%# the GNU General Public License and is only of importance to you if
+%# you choose to contribute your changes and enhancements to the
+%# community by submitting them to Best Practical Solutions, LLC.)
+%#
+%# By intentionally submitting any modifications, corrections or
+%# derivatives to this work, or any other work intended for use with
+%# Request Tracker, to Best Practical Solutions, LLC, you confirm that
+%# you are the copyright holder for those contributions and you grant
+%# Best Practical Solutions,  LLC a nonexclusive, worldwide, irrevocable,
+%# royalty-free, perpetual, license to use, copy, create derivative
+%# works based on those contributions, and sublicense and distribute
+%# those contributions and any derivatives thereof.
+%#
+%# END BPS TAGGED BLOCK }}}
+%   for my $user ( keys %$time_worked ) {
+      <div>
+        <span class="value"><% $user %>:</span>
+        <span class="value"><& /Ticket/Elements/ShowTime, minutes => $time_worked->{$user} &></span>
+      </div>
+%   }
+<%args>
+$time_worked => undef
+</%args>


### PR DESCRIPTION
This PR adds a new "LabelValueRow" component to extract and standardize how we show key-value pairs in lists in RT's UI.

This makes it easier to keep the style consistent, easier to update the style later and reduces boilerplate html in code.

Ideally, this PR would result in zero user-visible changes within RT.

As a demo, I've updated Ticket/Elements/ShowBasics to use the new component. 

This PR is currently a *draft* for initial review. If y'all believe this would be desirable change, I'm happy to update the entire codebase to use the new component, either as one PR or as a series of smaller PRs.

Since it's going to touch a lot of the UI, if you want the updates all together, I should probably do those updates in one pass in advance of a relatively quick merge or there will be numerous merge conflicts. 

If you want me to keep going, please let me know which branch I should be targeting and whether you have stylistic preferences.