### PR TITLE
Adding Auto-submitted: auto-generated header

### DIFF
--- a/lib/RT/Action/SendEmail.pm
+++ b/lib/RT/Action/SendEmail.pm
@@ -670,6 +670,7 @@ sub SetRTSpecialHeaders {
         }
     }
 
+    $self->SetHeader( 'Auto-Submitted', 'auto-generated' );
     $self->SetHeader( 'X-RT-Loop-Prevention', RT->Config->Get('rtname') );
     $self->SetHeader( 'X-RT-Ticket',
         RT->Config->Get('rtname') . " #" . $self->TicketObj->id() );


### PR DESCRIPTION


Currently, RT can protect itself against auto-generated messages it receives.

However it does not set the "Auto-Submitted: auto-generated" header itself, though all RT messages are basically machines-generated messages.

Consequently, if a robot is set as a message receipient in RT, it will answer this messages, leading to ticket pollution.

In addition, if the robot does not seet the Auto-submitted header itself, RT will in turn answer to the robot's answer, leading to SMTP loops.

Adding the Auto-Submitted: auto-generated header gives a chance to prevent such loops.

Now, you probably have very good reasons for not setting this header already, as I am probably not the first one to report this problem. I will therefore not complain if you reject this PR. But if you have a solution to prevent the loops I was speaking about, I would gladly read it!

Thanks for this very good product.

Best regards,
