### PR TITLE
'BasedOn' custom field options now works with autocomplete type

### DIFF
--- a/share/static/js/event-registration.js
+++ b/share/static/js/event-registration.js
@@ -94,6 +94,8 @@ jQuery(function() {
                 var vals;
                 if ( jQuery(this).is('select') ) {
                     vals = based_on.first().val();
+                } else if (jQuery(this).is('input[type="text"]')) {
+                    vals = based_on.val();
                 }
                 else {
                     vals = [];


### PR DESCRIPTION
Previously this option didn't do anything when a custom field was based on an field which set to the autocomplete type.

Fixes https://rt.bestpractical.com/Ticket/Display.html?id=37524

There maybe more elaborate solutions to prevent this JS firing when the autocomplete is 'in progress', but I went for the minimal approach.
