### PR TITLE
Created a CONTRIBUTING.pod for GitHub

### DIFF
--- a/CONTRIBUTING.pod
+++ b/CONTRIBUTING.pod
@@ -1,0 +1,19 @@
+=head1 Contributing
+
+=over
+
+=item * For contributions to this GitHub reposity, please see
+L<docs/hacking.pod|https:docs/hacking.pod> or
+L<Hacking - RT Documentation|https://docs.bestpractical.com/rt/latest/hacking.html>.
+
+=back
+
+=head3 Other Community Resources
+
+=over
+
+=item * L<Request Tracker Community Forum|https://forum.bestpractical.com>
+
+=item * L<Request Tracker Wiki|https://rt-wiki.bestpractical.com/>
+
+=back


### PR DESCRIPTION
Mentioned this idea in #349 -- thought I'd write it up in case you like it.

This file is a convenience for new contributors perusing the repository on GitHub.com. Basically it just functions as a signpost to the resources that people should be accessing (like `docs/hacking.pod`).

The presence of this file activates some GitHub features documented at [Setting guidelines for repository contributors - GitHub Docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors). This includes links on the "New pull request" form, and the https://github.com/bestpractical/rt/contribute route.

This functionality can also be activated by locating the file at `.github/CONTRIBUTING.pod`, but I think it's more convenient to have it visible at the repository root.

I tested the GitHub rendering of this Pod markup at [my fork](https://github.com/NReilingh/rt/blob/stable/CONTRIBUTING.pod).