### PR TITLE
Web.pm - use LoadByGecos after user autocreation

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -768,7 +768,7 @@ sub AttemptExternalAuth {
                     my $method = "Set$attribute";
                     $UserObj->$method( $new_user_info->{$attribute} ) if defined $new_user_info->{$attribute};
                 }
-                $HTML::Mason::Commands::session{'CurrentUser'}->Load($user);
+                $HTML::Mason::Commands::session{'CurrentUser'}->$load_method($user);
             } else {
                 RT->Logger->error("Couldn't auto-create user '$user' when attempting WebRemoteUser: $msg");
                 AbortExternalAuth( Error => "UserAutocreateDefaultsOnLogin" );


### PR DESCRIPTION
I was experiencing an edge case in my RT 5.0.3 installation after reconfiguring my setup to use WebRemote authentication with ExternalInfo. I am using the `WebRemoteUserGecos` option, and the LDAP source in use by `ExternalInfo` yields different values for `Name` and `Gecos`.

I was finding that after authenticating a new user, RT would display the "You are not allowed to log in" error message to the user, and was writing these log messages:

```
rt-demo       | [2962] [Tue Jan 24 00:14:33 2023] [info]: RT::User::CanonicalizeUserInfoFromExternalAuth returning Disabled: , EmailAddress: nicktest@example.com, Gecos: 1111111228, Name: nicktest, NickName: Nicktest, Privileged: , RealName: Nicktest Testlastname (/opt/rt5/sbin/../lib/RT/User.pm:982)
rt-demo       | [2962] [Tue Jan 24 00:14:33 2023] [error]: Couldn't find internal user for '1111111228' when attempting WebRemoteUser and RT is not configured for auto-creation. Refer to `perldoc /opt/rt5/docs/authentication.pod` if you want to allow auto-creation. (/opt/rt5/sbin/../lib/RT/Interface/Web.pm:823)
```

All the user had to do was reload the page to be authenticated properly, but this indicated to me that something was wrong with substituting the Gecos field with the Name field between creating the account and logging in.

I believe what is happening here is that after the new user is created and all of the values are set, then this line attempts to load a user by Name, but is still passing in the REMOTE_USER variable which is Gecos. I changed the line to follow the pattern on [line 742](https://github.com/bestpractical/rt/compare/4.4-trunk...NReilingh:rt:patch-2#diff-6f66a681023e5390fa0d520ed42ece68f3452ba0a2f5c9bfcd23c97a9b212702R742) and this seems to have solved the issue.

I would suggest reviewing the few lines of code above my change to ensure this is still correct when `WebRemoteUserGecos` is in use. I am not knowledgeable enough with Perl to say either way, but I recognize that this maps `User` to `$user` even though `$user` may be a `Gecos` value.