### PR TITLE
Support DateTime::Format::Natural >= 0.13_01

### DIFF
--- a/etc/cpanfile
+++ b/etc/cpanfile
@@ -136,6 +136,7 @@ on 'develop' => sub {
     requires 'Test::Expect', '>= 0.31';
     requires 'Test::LongString';
     requires 'Test::MockTime';
+    requires 'Test::MockTime::HiRes';
     requires 'Test::NoWarnings';
     requires 'Test::Pod';
     requires 'Test::Warn';

--- a/t/api/date.t
+++ b/t/api/date.t
@@ -1,5 +1,5 @@
 
-use Test::MockTime qw(set_fixed_time restore_time);
+use Test::MockTime::HiRes qw(set_fixed_time restore_time);
 use DateTime;
 
 use warnings;


### PR DESCRIPTION
Version 0.13_01 switched from using DateTime to DateTime::HiRes for setting the initial time. This means we in turn need to use Test::MockTime::HiRes. This patch works okay if DateTime::Format::Natural v0.13 is used.

Error I was getting in Debian with libdatetime-format-natural-perl v0.14 and v0.15:

  t/api/date.t .. 4/?
  #   Failed test 'April in the past'
  #   at t/api/date.t line 650.
  #          got: '2023-03-31 16:00:00'
  #     expected: '2015-03-31 16:00:00'

  #   Failed test 'Monday in the past'
  #   at t/api/date.t line 655.
  #          got: '2023-01-29 16:00:00'
  #     expected: '2015-11-22 16:00:00'

  #   Failed test 'April in the future'
  #   at t/api/date.t line 661.
  #          got: '2023-03-31 16:00:00'
  #     expected: '2016-03-31 16:00:00'
  # Some tests failed or we bailed out, tmp directory '/home/puck/personal/RT/debian/rt/request-tracker5/t/tmp/api-date.t-qhyuAiqU' is not cleaned
  # Looks like you failed 3 tests of 231.