### PR TITLE
RT_Config.pm.in: PriorityAsString clarity for perl noobs

### DIFF
--- a/etc/RT_Config.pm.in
+++ b/etc/RT_Config.pm.in
@@ -2859,24 +2859,24 @@ giving a unique number to each.
 
     Set(%PriorityAsString,
         Default => { Low => 0, Medium => 50, High => 100 },
-        General => [ Medium => 50, Low => 0, High => 80, 'On Fire' => 100],
+        General => [ Medium, 50, Low, 0, High, 80, 'On Fire', 100],
         Support => 0,
     );
 
 The key is queue name or "Default", which is the fallback for unspecified
-queues. Values can be an ArrayRef, HashRef, or C<0>.
+queues. Values can be an HashRef, ArrayRef, or C<0>.
 
 =over
-
-=item ArrayRef
-
-This is the ordered String => Number map list. Priority options will be
-rendered in the order they are listed in the list.
 
 =item HashRef
 
 This is the unordered String => Number map list. Priority options will be
 rendered in numerical ascending order.
+
+=item ArrayRef
+
+This is the ordered String => Number map list. Priority options will be
+rendered in the order they are listed in the list.
 
 =item C<0>
 


### PR DESCRIPTION
For your consideration:

Speaking from the perspective of someone who has not been hacking with perl for decades, I was recently trying to configure this setting in RT5's web interface, and had to do a bit of head-scratching. One change here is reordering HashRef and ArrayRef to match the code example, though perhaps it is preferred to reorder the code example instead of the text - either way, they should be consistent for people who are not familiar with the terminology.

The other change is to express the ArrayRef with commas instead of fat arrows. In RT5's web interface, these kinds of values are provided as JSON which is then deserialized/reserialized into Perl's object syntax, but from looking at the fat arrows in the ArrayRef example, it's not necessarily obvious that the JSON serialization of this is just going to be an array of scalars. I tried both `"General": [ {"Medium": 50}, {"Low": 0} ]` and `"General": [ {"Medium": 50, "Low": 0} ]` before I remembered that `=>` is equivalent to `,` and should try a regular array.

Not the first time I've been confused by this while working with RT5's web configuration... but I'm getting better. Still I think it would be worthwhile to think about helping non-perl-native admins translate the perl syntax to JSON.