### PR TITLE
This patch adds user "chips" which is the first step to being able to

### DIFF
--- a/share/html/Elements/ShowUser
+++ b/share/html/Elements/ShowUser
@@ -84,8 +84,10 @@ $Address => undef
 $style => undef
 $Link => 1
 $LinkTarget => ''
+$ShowUserChip => 1
 </%ARGS>
 <span class="user" <% $User && $User->id ? 'data-user-id="'.$User->id.'"' : "" |n %>>\
+<% $ShowUserChip ? $m->scomp('/Elements/ShowUserChip', User => $User) : '' |n %>\
 % if ($Link and $User and $User->id and not $system_user{$User->id} and $session{CurrentUser}->Privileged) {
 <a <% $LinkTarget ? "target=$LinkTarget" : '' |n %> href="<% RT->Config->Get("WebPath") %>/User/Summary.html?id=<% $User->id %>">\
 <% $display %>\

--- a/share/html/Elements/ShowUserChip
+++ b/share/html/Elements/ShowUserChip
@@ -1,0 +1,41 @@
+<%args>
+$User => undef
+</%args>
+<%init>
+use List::Util qw(reduce);
+my $color_list = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728",
+    "#9467bd", "#8c564b", "#e377c2", "#7f7f7f"
+];
+
+my $staff_colors = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728",
+    "#9467bd", "#8c564b", "#e377c2", "#7f7f7f"
+];
+my $nonstaff_colors = [
+    "#17becf", "#bcbd22", "#7f7f7f", "#8c564b",
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"
+];
+my @words         = split( ' ', ( $User->RealName || $User->Name || '' ) );
+my $first_initial = substr( $words[0], 0, 1 );
+shift @words;
+my $last_initial = substr( $words[-1], 0, 1 );
+my $initials     = $first_initial . $last_initial;
+
+my $color_index = reduce { $a + ord($b) } 0, split( '', $User->id );
+my $color;
+
+if ( $User->Privileged ) {
+    $color = $staff_colors->[ $color_index % scalar(@$color_list) ];
+} else {
+
+    $color = $nonstaff_colors->[ $color_index % scalar(@$color_list) ];
+}
+if ( $User->id == RT::System->id ) {
+    $initials = 'RT';
+    $color    = '#bbbbbb';
+}
+</%init>
+<div class="user-chip d-inline-block " style="transform: scale(0.7);">
+<div class="rounded p-1 px-2 w-3 h-2" style="background-color: <%$color%>; color: white; font-weight: bold;"><%$initials%></div>
+</div>


### PR DESCRIPTION
add modern user-icons in RT's UI. The code pulls out the user's initials and renders them inline inside a rounded rectangle.

It uses one set of colors for staff and another set of colors for non-staff. This is a first pass for discussion and later improvement. I'm not in love with the colors.