### PR TITLE
fix rt-bugs #37601 - add rt-clean-shorteners

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -139,9 +139,9 @@ BINARIES		=	$(RT_MAILGATE_BIN) \
 				$(RT_CRON_BIN)
 
 SYSTEM_BINARIES		=	rt-attributes-viewer \
-				rt-munge-attachments \
 				rt-clean-attributes \
 				rt-clean-sessions \
+				rt-clean-shorteners \
 				rt-dump-initialdata \
 				rt-dump-metadata \
 				rt-email-dashboards \
@@ -151,6 +151,7 @@ SYSTEM_BINARIES		=	rt-attributes-viewer \
 				rt-fulltext-indexer \
 				rt-importer \
 				rt-ldapimport \
+				rt-munge-attachments \
 				rt-passwd \
 				rt-preferences-viewer \
 				rt-search-attributes \


### PR DESCRIPTION
This fixes https://rt.bestpractical.com/Ticket/Display.html?id=37601 
The new rt-clean-shorteners was never added to the sbin path