### PR TITLE
fix rt-bugs #37600

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -1517,7 +1517,7 @@ our %IS_WHITELISTED_COMPONENT = (
 );
 
 our @WHITELISTED_RESULT_PAGES = (
-    '/Search/Results.html',
+    qr/\/Search\/Results\.html$/,
 );
 
 # Whitelist arguments that do not indicate an effectful request.


### PR DESCRIPTION
This fixes https://rt.bestpractical.com/Ticket/Display.html?id=37600 which should ignore leading subdirectories. Note that there are a lot other WHITELIST* checks which all do not honor a configured subdirectory