### PR TITLE
AutoOpenInactive bugfix and action prepare return values

### DIFF
--- a/lib/RT/Action/AutoOpen.pm
+++ b/lib/RT/Action/AutoOpen.pm
@@ -82,15 +82,15 @@ sub Prepare {
 
     my $ticket = $self->TicketObj;
     my $next = $ticket->FirstActiveStatus;
-    return 1 unless defined $next;
+    return 0 unless defined $next;
 
     # no change if the ticket is in initial status and the message is a mail
     # from a requestor
-    return 1 if $ticket->LifecycleObj->IsInitial($ticket->Status)
+    return 0 if $ticket->LifecycleObj->IsInitial($ticket->Status)
         && $self->TransactionObj->IsInbound;
 
     if ( my $msg = $self->TransactionObj->Message->First ) {
-        return 1 if ($msg->GetHeader('RT-Control') || '') =~ /\bno-autoopen\b/i;
+        return 0 if ($msg->GetHeader('RT-Control') || '') =~ /\bno-autoopen\b/i;
     }
 
     $self->{'set_status_to'} = $next;

--- a/lib/RT/Action/AutoOpenInactive.pm
+++ b/lib/RT/Action/AutoOpenInactive.pm
@@ -71,7 +71,7 @@ sub Prepare {
     my $self = shift;
 
     my $ticket = $self->TicketObj;
-    return 0 if $ticket->LifecycleObj->IsActive( $ticket->Status );
+    return 0 unless $ticket->LifecycleObj->IsInactive( $ticket->Status );
 
     if ( my $msg = $self->TransactionObj->Message->First ) {
         return 0

--- a/lib/RT/Action/LinearEscalate.pm
+++ b/lib/RT/Action/LinearEscalate.pm
@@ -157,22 +157,22 @@ sub Prepare {
 
     unless ( $ticket->DueObj->IsSet ) {
         $RT::Logger->debug('Due is not set. Not escalating.');
-        return 1;
+        return 0;
     }
 
     my $priority_range = ($ticket->FinalPriority ||0) - ($ticket->InitialPriority ||0);
     unless ( $priority_range ) {
         $RT::Logger->debug('Final and Initial priorities are equal. Not escalating.');
-        return 1;
+        return 0;
     }
 
     if ( $ticket->Priority >= $ticket->FinalPriority && $priority_range > 0 ) {
         $RT::Logger->debug('Current priority is greater than final. Not escalating.');
-        return 1;
+        return 0;
     }
     elsif ( $ticket->Priority <= $ticket->FinalPriority && $priority_range < 0 ) {
         $RT::Logger->debug('Current priority is lower than final. Not escalating.');
-        return 1;
+        return 0;
     }
 
     # TODO: compute the number of business days until the ticket is due
@@ -186,7 +186,7 @@ sub Prepare {
     # do nothing if we didn't reach starts or created date
     if ( $starts > $now ) {
         $RT::Logger->debug('Starts(Created) is in future. Not escalating.');
-        return 1;
+        return 0;
     }
 
     my $due = $ticket->DueObj->Unix;

--- a/lib/RT/Action/SetStatus.pm
+++ b/lib/RT/Action/SetStatus.pm
@@ -116,13 +116,13 @@ sub Prepare {
         ($next) = grep $lifecycle->$method($_), $lifecycle->Transitions($status);
         unless ( $next ) {
             $RT::Logger->info("No transition from '$status' to $argument set");
-            return 1;
+            return 0;
         }
     }
     elsif ( $lifecycle->IsValid( $argument ) ) {
         unless ( $lifecycle->IsTransition( $status => $argument ) ) {
             $RT::Logger->warning("Transition '$status -> $argument' is not valid");
-            return 1;
+            return 0;
         }
         $next = $argument;
     }


### PR DESCRIPTION
This PR originated as an unexpected behavior on my production RT instance. I noticed that tickets were being moved into open status unexpectedly -- for example, a new ticket that the requestor made the first reply to would be opened by the requestor's reply.

I initially thought this was a bug in `AutoOpen`, so I went looking through the code of it and other actions. I came across a sort of red herring -- that the `Prepare` guards were returning true instead of false. These actually don't have a functional effect because the `Commit` phase will return early if the last part of `Prepare` is not reached, but they do make the debug log messages more confusing since, really, `Commit` should never be run if `Prepare` fails to satisfy all of its guard clauses.

Eventually, though, I realized that `AutoOpenInactive` was running _not just_ on `inactive` statuses (but also on `initial` statuses), and so _it_ was the culprit of my "new tickets being auto-opened" problem.

I am submitting these two commits to fix the bug in `AutoOpenInactive` so that its behavior matches its documentation and name (only operating on tickets in an `inactive` status), and to clean up the `Prepare` blocks of three RT Actions so that the return value semantics are more correct.