### PR TITLE
SetStatus docs proofreading and 'apropriate' typos

### DIFF
--- a/lib/RT/Action/Autoreply.pm
+++ b/lib/RT/Action/Autoreply.pm
@@ -87,7 +87,7 @@ sub SetRecipients {
 
 =head2 SetReturnAddress
 
-Set this message's return address to the apropriate queue address
+Set this message's return address to the appropriate queue address
 
 =cut
 

--- a/lib/RT/Action/SetStatus.pm
+++ b/lib/RT/Action/SetStatus.pm
@@ -90,7 +90,7 @@ according to transitions to the target set, for example:
 
     * The current status is 'open'
     * Argument of this action is 'inactive'
-    * Possible transitions from 'open' are 'resolved', 'rejected' or 'deleted'
+    * Possible transitions from 'open' are 'resolved', 'rejected', or 'deleted'
     * Status is changed to 'resolved'
 
 =back

--- a/lib/RT/Action/SetStatus.pm
+++ b/lib/RT/Action/SetStatus.pm
@@ -82,7 +82,7 @@ transitions, for example:
 However, in the example above Status is not changed if the argument is any other
 literal status, since no other transitions are allowed by the lifecycle.
 
-=item 'initial', 'active' or 'inactive'
+=item 'initial', 'active', or 'inactive'
 
 Status is changed from the current value to the first possible 'initial',
 'active', or 'inactive' status accordingly. First possible value is determined

--- a/lib/RT/Action/SetStatus.pm
+++ b/lib/RT/Action/SetStatus.pm
@@ -60,7 +60,7 @@ RT::Action::SetStatus - RT's scrip action to set status of a ticket
 
 This action changes status to a new value according to the rules in L</ARGUMENT>.
 Status is not changed if the transition is invalid or another error occurs. All
-issues are logged at apropriate levels.
+issues are logged at appropriate levels.
 
 =head1 ARGUMENT
 
@@ -70,22 +70,22 @@ Argument can be one of the following:
 
 =item status literally
 
-Status is changed from the current value to a new defined by the argument,
-but only if it's valid status and allowed by transitions of the current lifecycle,
-for example:
+Status is changed from the current value to a new value defined by the argument,
+but only if it is a valid status and allowed by the current lifecycle's
+transitions, for example:
 
     * The current status is 'stalled'
     * Argument of this action is 'open'
-    * The only possible transition in the scheam from 'stalled' is 'open'
-    * Status is changed
+    * The lifecycle's only valid transition from 'stalled' is to 'open'
+    * Status is changed to 'open'
 
-However, in the example above Status is not changed if argument is anything
-else as it's just not allowed by the lifecycle.
+However, in the example above Status is not changed if the argument is any other
+literal status, since no other transitions are allowed by the lifecycle.
 
 =item 'initial', 'active' or 'inactive'
 
-Status is changed from the current value to first possible 'initial',
-'active' or 'inactive' correspondingly. First possible value is figured
+Status is changed from the current value to the first possible 'initial',
+'active', or 'inactive' status accordingly. First possible value is determined
 according to transitions to the target set, for example:
 
     * The current status is 'open'

--- a/lib/RT/Group.pm
+++ b/lib/RT/Group.pm
@@ -1146,7 +1146,7 @@ sub HasMemberRecursively {
 =head2 DeleteMember PRINCIPAL_ID
 
 Takes the principal id of a current user or group.
-If the current user has apropriate rights,
+If the current user has appropriate rights,
 removes that GroupMember from this group.
 Returns a two value array. the first value is true on successful 
 addition or 0 on failure.  The second value is a textual status msg.


### PR DESCRIPTION
I initially just noticed the "scheam" typo in SetStatus.pm and was just going to submit that, but then I noticed that the rest of the docs in the same module could use an edit pass for clarity, spelling, and grammar.

I also noticed that "apropriate" was misspelled in a few other places, so I searched it in the codebase and corrected the other user-facing instances.