### PR TITLE
ticket_metadata.pod: Incorrect documentation of parent/child

### DIFF
--- a/docs/ticket_metadata.pod
+++ b/docs/ticket_metadata.pod
@@ -141,8 +141,9 @@ will update itself with the opposite relationship).
 
 =head2 Parent
 
-Parent tickets have children tickets, all of which must be resolved before the
-parent ticket can be resolved.
+Parent tickets have children tickets, which perhaps were opened as a result of
+investigating the parent ticket. Parent and children do not enforce a resolution
+order.
 
 How would one use this information in searches? Let's say you're using RT to
 manage a release of the software your company makes. Often times release


### PR DESCRIPTION
DependsOn/DependedOnBy is the link type that enforces that one ticket is resolved before another. Parent/Child does not enforce a resolution order.

This seems to be a common misconception, as the O'Reilly book "RT Essentials" was printed with the same mistake. (This is corrected in [the book's errata available from the publisher](https://www.oreilly.com/catalog/errata.csp?isbn=9780596006686).

I made a best effort at rewriting "all of which must be resolved before the parent ticket can be resolved". Feel free to rewrite if you'd prefer to make the correction in a different way.