### PR TITLE
Fix pod heading

### DIFF
--- a/sbin/rt-munge-attachments.in
+++ b/sbin/rt-munge-attachments.in
@@ -130,7 +130,7 @@ my ( $ret, $msg ) = $attachments->ReplaceAttachments(
 print STDERR $msg . "\n";
 
 
-=head1 rt-munge-attachments
+=head1 NAME
 
 rt-munge-attachments - Remove or replace strings in attachment records
 


### PR DESCRIPTION
This resulted in perldoc (etc) output that looked like:

```
rt-munge-attachments
    rt-munge-attachments - Remove or replace strings in attachment records

SYNOPSIS
...
```

which I doubt is intended.

Patch in Debian: https://salsa.debian.org/request-tracker-team/request-tracker5/-/blob/master/debian/patches/fix_pod_rt_munge_attachments.diff