### PR TITLE
5.0/add create tickets template gui

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -3171,6 +3171,115 @@ sub ProcessCustomFieldUpdates {
     return (@results);
 }
 
+=head2 ProcessTemplateUpdate ( TemplateObj => $Template, ARGSRef => \%ARGS );
+
+Returns an array of results messages.
+
+=cut
+
+sub ProcessTemplateUpdate {
+    my %args = (
+        TemplateObj => undef,
+        ARGSRef     => undef,
+        @_
+    );
+
+    my @results;
+    my @FIELDS = qw(
+        PerlCode
+        Queue
+        Subject
+        Status
+        SLA
+        Due
+        Starts
+        Started
+        Resolved
+        Owner
+        Requestor
+        Cc
+        AdminCc
+        RequestorGroup
+        CcGroup
+        AdminCcGroup
+        TimeWorked
+        TimeEstimated
+        TimeLeft
+        InitialPriority
+        FinalPriority
+        Type
+        DependsOn
+        DependedOnBy
+        RefersTo
+        ReferredToBy
+        Members
+        MemberOf
+        CustomFields
+        Content
+        ContentType
+        UpdateType
+        SkipCreate
+    );
+
+    # ensure $args{ARGSRef}{CreateSectionName} is an array ref
+    # could be undefined (new template), scalar (single section), or an array ref (multiple sections)
+    if ( $args{ARGSRef}{CreateSectionName} ) {
+        $args{ARGSRef}{CreateSectionName} = [ $args{ARGSRef}{CreateSectionName} ]
+            unless ref $args{ARGSRef}{CreateSectionName};
+    }
+    else {
+        $args{ARGSRef}{CreateSectionName} = [];
+    }
+
+    push @{ $args{ARGSRef}{CreateSectionName} }, 'ADD-NEW-SECTION'
+        if $args{ARGSRef}{AddNewSectionName};
+
+    if ( @{ $args{ARGSRef}{CreateSectionName} } ) {
+        my $new_content = '';
+        for my $name ( @{ $args{ARGSRef}{CreateSectionName} } ) {
+            my $template_name = $name eq 'ADD-NEW-SECTION' ? $args{ARGSRef}{AddNewSectionName} : $name;
+            $new_content .= "===Create-Ticket: $template_name\n";
+            for my $field ( @FIELDS ) {
+            if ( $field eq "CustomFields" ) {
+                while ( my $cf_id = shift @{ $args{ARGSRef}{ $name . "-CustomField-id" } || [] } ) {
+                my $cf_val = shift @{ $args{ARGSRef}{ $name . "-CustomField-val" } || [] };
+                    $new_content .= "CustomField-$cf_id: $cf_val\n";
+                }
+            }
+            else {
+                if ( my $val = $args{ARGSRef}{"$name-$field"} ) {
+                if ( $field eq 'PerlCode' ) {
+                    # trim leading and trailing whitespace
+                    $val =~ s/^\s+//;
+                    $val =~ s/\s+$//;
+                    $new_content .= "{\n$val\n}\n";
+                }
+                elsif ( $field eq 'Content' ) {
+                    $new_content .= "Content: $val\nENDOFCONTENT\n"
+                }
+                else {
+                    $new_content .= "$field: $val\n";
+                }
+                }
+            }
+            }
+        }
+        $args{ARGSRef}{Content} = $new_content;
+    }
+
+    my @attribs = qw( Name Description Queue Type Content );
+    my @aresults = UpdateRecordObject(
+        AttributesRef => \@attribs,
+        Object        => $args{TemplateObj},
+        ARGSRef       => $args{ARGSRef}
+    );
+    push @results, @aresults;
+
+    my ( $ok, $msg ) = $args{TemplateObj}->CompileCheck;
+    push @results, $msg if !$ok;
+
+    return ( @results );
+}
 
 
 =head2 ProcessTicketBasics ( TicketObj => $Ticket, ARGSRef => \%ARGS );

--- a/lib/RT/Interface/Web/MenuBuilder.pm
+++ b/lib/RT/Interface/Web/MenuBuilder.pm
@@ -1430,6 +1430,13 @@ sub _BuildAdminMenu {
                 $templates->child( select => title => loc('Select'), path => "/Admin/Queues/Templates.html?id=".$id);
                 $templates->child( create => title => loc('Create'), path => "/Admin/Queues/Template.html?Create=1;Queue=".$id);
 
+                if ( $HTML::Mason::Commands::m->request_args->{'Template'} && $HTML::Mason::Commands::m->request_args->{'Template'} =~ /^\d+$/ ) {
+                    my $template_id = $HTML::Mason::Commands::m->request_args->{'Template'};
+                    $templates->child( basics => title => loc('Basics'), path => "/Admin/Queues/Template.html?Queue=$id&Template=$template_id" );
+                    $templates->child( content => title => loc('Content'), path => "/Admin/Queues/Template.html?Queue=$id&ContentTab=1&Template=$template_id" );
+                    $templates->child( advanced => title => loc('Advanced'), path => "/Admin/Queues/Template.html?Queue=$id&AdvancedTab=1&Template=$template_id" );
+                }
+
                 my $scrips = $queue->child( scrips => title => loc('Scrips'), path => "/Admin/Queues/Scrips.html?id=" . $id);
                 $scrips->child( select => title => loc('Select'), path => "/Admin/Queues/Scrips.html?id=" . $id );
                 $scrips->child( create => title => loc('Create'), path => "/Admin/Scrips/Create.html?Queue=" . $id);

--- a/lib/RT/Interface/Web/MenuBuilder.pm
+++ b/lib/RT/Interface/Web/MenuBuilder.pm
@@ -1655,8 +1655,21 @@ sub _BuildAdminMenu {
     }
 
     if ( $request_path =~ m{^/Admin/Global/Templates?\.html} ) {
-        $page->child( select => title => loc('Select'), path => "/Admin/Global/Templates.html" );
-        $page->child( create => title => loc('Create'), path => "/Admin/Global/Template.html?Create=1" );
+        if ( $HTML::Mason::Commands::m->request_args->{'Template'} && $HTML::Mason::Commands::m->request_args->{'Template'} =~ /^\d+$/ ) {
+            my $id = $HTML::Mason::Commands::m->request_args->{'Template'};
+            my $queue = $HTML::Mason::Commands::m->request_args->{'Queue'} || 0;
+            my $templates = $page->child( select => title => loc('Templates'),
+                                          path => "/Admin/Global/Templates.html" );
+            $templates->child( select => title => loc('Select'), path => "/Admin/Global/Templates.html" );
+            $templates->child( create => title => loc('Create'), path => "/Admin/Global/Template.html?Create=1" );
+            $page->child( basics => title => loc('Basics'), path => "/Admin/Global/Template.html?Queue=$queue&Template=$id" );
+            $page->child( content => title => loc('Content'), path => "/Admin/Global/Template.html?Queue=$queue&ContentTab=1&Template=$id" );
+            $page->child( advanced => title => loc('Advanced'), path => "/Admin/Global/Template.html?Queue=$queue&AdvancedTab=1&Template=$id" );
+        }
+        else {
+            $page->child( select => title => loc('Select'), path => "/Admin/Global/Templates.html" );
+            $page->child( create => title => loc('Create'), path => "/Admin/Global/Template.html?Create=1" );
+        }
     }
 
     if ( $request_path =~ m{^/Admin/Articles/Classes/} ) {

--- a/share/html/Admin/Elements/ModifyCreateTemplate
+++ b/share/html/Admin/Elements/ModifyCreateTemplate
@@ -1,0 +1,528 @@
+%# BEGIN BPS TAGGED BLOCK {{{
+%#
+%# COPYRIGHT:
+%#
+%# This software is Copyright (c) 1996-2023 Best Practical Solutions, LLC
+%#                                          <sales@bestpractical.com>
+%#
+%# (Except where explicitly superseded by other copyright notices)
+%#
+%#
+%# LICENSE:
+%#
+%# This work is made available to you under the terms of Version 2 of
+%# the GNU General Public License. A copy of that license should have
+%# been provided with this software, but in any event can be snarfed
+%# from www.gnu.org.
+%#
+%# This work is distributed in the hope that it will be useful, but
+%# WITHOUT ANY WARRANTY; without even the implied warranty of
+%# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%# General Public License for more details.
+%#
+%# You should have received a copy of the GNU General Public License
+%# along with this program; if not, write to the Free Software
+%# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+%# 02110-1301 or visit their web page on the internet at
+%# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
+%#
+%#
+%# CONTRIBUTION SUBMISSION POLICY:
+%#
+%# (The following paragraph is not intended to limit the rights granted
+%# to you to modify and distribute this software under the terms of
+%# the GNU General Public License and is only of importance to you if
+%# you choose to contribute your changes and enhancements to the
+%# community by submitting them to Best Practical Solutions, LLC.)
+%#
+%# By intentionally submitting any modifications, corrections or
+%# derivatives to this work, or any other work intended for use with
+%# Request Tracker, to Best Practical Solutions, LLC, you confirm that
+%# you are the copyright holder for those contributions and you grant
+%# Best Practical Solutions,  LLC a nonexclusive, worldwide, irrevocable,
+%# royalty-free, perpetual, license to use, copy, create derivative
+%# works based on those contributions, and sublicense and distribute
+%# those contributions and any derivatives thereof.
+%#
+%# END BPS TAGGED BLOCK }}}
+% if ( @sections ) {
+  <ul class="nav nav-tabs" role="tablist">
+% for my $template ( @sections ) {
+    <li class="nav-item" id="<% $template->{name} %>-nav">
+      <a class="nav-link <% $template->{active} ? 'active' : ''  %>" href="#<% $template->{name} %>-content" id="<% "category-tab-" . $template->{name} %>" data-toggle="tab" role="tab" aria-controls="<% $template->{name} %>" aria-selected="false">
+        <% $template->{name} eq 'ADD-NEW-SECTION' ? 'Add New Section' : $template->{name}  %>
+      </a>
+    </li>
+% }
+  </ul>
+  <div class="tab-content">
+% for my $template ( @sections ) {
+    <div id="<% $template->{name} %>-content" class="tab-pane fade <% $template->{active} ? 'show active' : ''  %>" role="tabpanel" aria-labelledby="<% "category-tab-" . $template->{name} %>">
+<&| /Widgets/TitleBox, title => loc("Perl Code"), class=>'ticket-info-basics' &>
+%   if ( $template->{name} eq 'ADD-NEW-SECTION' ) {
+      <&| /Elements/LabeledValue, Label => loc('Section Name'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="AddNewSectionName" type="text" value="" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+% }
+% else {
+    <input type="hidden" name="CreateSectionName" value="<% $template->{name} %>">
+% }
+
+      <&| /Elements/LabeledValue, Label => loc('Perl Code'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+% my $perlcode = $template->{perlcode} || '';
+% $perlcode =~ s/^\s?{//;
+% $perlcode =~ s/}\s?$//;
+          <textarea class="form-control" name="<% $template->{name} %>-PerlCode" cols="50" rows="3"><% $perlcode %></textarea>
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Skip Create'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-SkipCreate" type="text" value="<% $template->{skipcreate} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+</&>
+
+<&| /Widgets/TitleBox, title => loc("Content"), class=>'ticket-info-basics' &>
+      <&| /Elements/LabeledValue, Label => loc('Update Type'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-UpdateType" type="text" value="<% $template->{updatetype} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Content Type'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-ContentType" type="text" value="<% $template->{contenttype} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Content'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <textarea class="form-control" name="<% $template->{name} %>-Content" cols="50" rows="3"><% $template->{content} || '' %></textarea>
+        </div>
+      </div>
+      </&>
+</&>
+
+<div class="form-row">
+<div class="boxcontainer col-md-6">
+<&| /Widgets/TitleBox, title => loc("The Basics"), class=>'ticket-info-basics' &>
+      <&| /Elements/LabeledValue, Label => loc('Type'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Type" type="text" value="<% $template->{type} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Subject'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Subject" type="text" value="<% $template->{subject} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Status'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Status" type="text" value="<% $template->{status} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Queue'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Queue" type="text" value="<% $template->{queue} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('SLA'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-SLA" type="text" value="<% $template->{sla} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Time Estimated'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-TimeEstimated" type="text" value="<% $template->{timeestimated} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Time Worked'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-TimeWorked" type="text" value="<% $template->{timeworked} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Time Left'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-TimeLeft" type="text" value="<% $template->{timeleft} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Initial Priority'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-InitialPriority" type="text" value="<% $template->{initialpriority} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Final Priority'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-FinalPriority" type="text" value="<% $template->{finalpriority} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+</&>
+
+<&| /Widgets/TitleBox, title => loc("People"), class=>'ticket-info-people' &>
+      <&| /Elements/LabeledValue, Label => loc('Owner'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Owner" type="text" value="<% $template->{owner} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Requestor'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Requestor" type="text" value="<% $template->{requestor} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Cc'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Cc" type="text" value="<% $template->{cc} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Admin Cc'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-AdminCc" type="text" value="<% $template->{admincc} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Requestor Group'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-RequestorGroup" type="text" value="<% $template->{requestorgroup} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Cc Group'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-CcGroup" type="text" value="<% $template->{ccgroup} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Admin Cc Group'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-AdminCcGroup" type="text" value="<% $template->{adminccgroup} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+</&>
+</div>
+<div class="boxcontainer col-md-6">
+<&| /Widgets/TitleBox, title => loc("Dates"), class=>'ticket-info-dates' &>
+      <&| /Elements/LabeledValue, Label => loc('Starts'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Starts" type="text" value="<% $template->{starts} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Started'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Started" type="text" value="<% $template->{started} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Due'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Due" type="text" value="<% $template->{due} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Resolved'), Class => 'edit-custom-field' &>
+  <div class="form-row">
+    <div class="col-12">
+      <input name="<% $template->{name} %>-Resolved" type="text" value="<% $template->{resolved} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+</&>
+
+<&| /Widgets/TitleBox, title => loc("Links"), class=>'ticket-info-links' &>
+      <&| /Elements/LabeledValue, Label => loc('Depends On'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-DependsOn" type="text" value="<% $template->{dependson} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Depended On By'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-DependedOnBy" type="text" value="<% $template->{dependedonby} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Refers To'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-RefersTo" type="text" value="<% $template->{refersto} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Referred To By'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-ReferredToBy" type="text" value="<% $template->{referredtoby} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Members (Children)'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-Members" type="text" value="<% $template->{members} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+
+      <&| /Elements/LabeledValue, Label => loc('Member Of (Parents)'), Class => 'edit-custom-field' &>
+      <div class="form-row">
+        <div class="col-12">
+          <input name="<% $template->{name} %>-MemberOf" type="text" value="<% $template->{memberof} || '' %>" size="50" class="form-control" />
+        </div>
+      </div>
+      </&>
+</&>
+
+<&| /Widgets/TitleBox, title => loc("Custom Fields"), class=>'ticket-info-cfs' &>
+      <&| /Elements/LabeledValue, Label => loc('Custom Fields'), Class => 'edit-custom-field' &>
+<div id="CustomFields-<% $template->{name} %>">
+%   foreach my $cf ( @{ $template->{CustomFields} || [] } ) {
+%     my ( $cf_id, $value ) = @$cf;
+      <div class="form-row" id="<% $template->{name} %>-CustomField-<% $cf_id || '' %>">
+        <div class="col-5">
+          <select name="<% $template->{name} %>-CustomField-id" class="form-control selectpicker">
+%       my $cfs = RT::CustomFields->new( $session{'CurrentUser'});
+%       $cfs->LimitToGlobal;
+%       $cfs->OrderBy( FIELD => 'Name', ORDER => 'ASC' );
+            <option value=""></option>
+%       while ( my $cf = $cfs->Next ) {
+            <option value="<% $cf->id %>" <% $cf_id eq $cf->id ? 'selected' : '' %>><% $cf->Name  %></option>
+% }
+          </select>
+        </div>
+        <div class="col-5">
+          <input name="<% $template->{name} %>-CustomField-val" type="text" value="<% $value || '' %>" size="50" class="form-control" />
+        </div>
+        <div class="col-2">
+          <input type="submit" class="button btn btn-primary" name="<% $template->{name} %>-RemoveCustomField-<% $cf_id %>" value=" - " onclick="RemoveCustomField('<% $template->{name} %>-CustomField-<% $cf_id || '' %>'); return false;">
+        </div>
+      </div>
+%   }
+      </&>
+</div>
+      <div class="form-row">
+        <div class="col-12 text-right">
+          <input type="submit" class="button btn btn-primary form-control" name="<% $template->{name} %>-AddCustomField" value="<% loc("Add Custom Field") %>" onclick="AddCustomField('<% $template->{name} %>'); return false;">
+        </div>
+      </div>
+</&>
+</div>
+</div>
+%   unless ( $template->{name} eq 'ADD-NEW-SECTION' ) {
+      <div class="text-right">
+        <button class="btn btn-danger" id="<% $template->{name} %>-button" type="button" onclick="RemoveSection('<% $template->{name} %>'); return false;">Delete Section</button>
+      </div>
+%   }
+    </div>
+% }
+  </div>
+% }
+
+<script type="text/javascript">
+  function RemoveSection ($name) {
+    jQuery( "#" + $name + "-nav" ).remove();
+    jQuery( "#" + $name + "-button" ).remove();
+    jQuery( "#" + $name + "-content" ).remove();
+    // trigger a click on the first remaining tab link
+    jQuery(".nav-link").first().trigger('click');
+  };
+
+  function RemoveCustomField ($div_id) {
+    jQuery( "#" + $div_id ).remove();
+  };
+
+  var $new_cf_count = 1;
+
+  function AddCustomField ($ticket_name) {
+    var $html = ' \
+      <div class="form-row" id="' + $ticket_name + '-CustomField-new-' + $new_cf_count.toString() + '"> \
+        <div class="col-5"> \
+          <select name="' + $ticket_name + '-CustomField-id" class="form-control selectpicker"> \
+%       my $cfs = RT::CustomFields->new( $session{'CurrentUser'});
+%       $cfs->LimitToGlobal;
+%       $cfs->OrderBy( FIELD => 'Name', ORDER => 'ASC' );
+            <option value=""></option> \
+%       while ( my $cf = $cfs->Next ) {
+            <option value="<% $cf->id %>"><% $cf->Name  %></option> \
+% }
+          </select> \
+        </div> \
+        <div class="col-5"> \
+          <input name="' + $ticket_name + '-CustomField-val" type="text" value="" size="50" class="form-control" /> \
+        </div> \
+        <div class="col-2"> \
+          <input type="submit" class="button btn btn-primary" name="' + $ticket_name + '-RemoveCustomField-' + $ticket_name + '" value=" - " onclick="RemoveCustomField(\'' + $ticket_name + '-CustomField-new-' + $new_cf_count.toString() + '\'); return false;"> \
+        </div> \
+      </div>';
+      $new_cf_count++;
+    jQuery( "#CustomFields-" + $ticket_name ).append($html);
+    jQuery('.selectpicker').selectpicker();
+  };
+</script>
+<%INIT>
+my ( $template_object, @sections, $Template );
+if ( $TemplateObj && $TemplateObj->Id ) {
+    $template_object = RT::Template->new( RT->SystemUser );
+    if ( $QueueObj ) {
+      $template_object->LoadQueueTemplate( Queue => $QueueObj->id, Name => $TemplateObj->Name );
+    }
+    else {
+      $template_object->LoadGlobalTemplate( $TemplateObj->Name );
+    }
+
+    $Template = $template_object->Name;
+
+    if ( $template_object->id ) {
+        my $content = $template_object->Content || '';
+        if ( substr( $content, 0, 3 ) eq '===' ) {
+
+            # parse the content and load gui controls
+            my ( $current_ticket, %current_section );
+            my @lines = split /\n/, $content;
+            while ( my $line = shift @lines ) {
+              if ( $line =~ /^===(.*)-Ticket: (.*)$/ ) {
+                # TODO: do we need to do anything different for different ticket action?
+                #       Create vs Update vs Base
+                my $ticket_action = $1;
+                my $ticket_name   = $2;
+
+                if ( ! $current_ticket ) {
+                  # first ticket template
+                  $current_ticket           = $ticket_name;
+                  $current_section{name}   = $ticket_name;
+                  $current_section{action} = $ticket_action;
+                  $current_section{active} = 1;
+                }
+                elsif ( $ticket_name ne $current_ticket ) {
+                  # new ticket template
+                  push @sections, { %current_section };
+                  %current_section         = ();
+                  $current_ticket           = $ticket_name;
+                  $current_section{name}   = $ticket_name;
+                  $current_section{action} = $ticket_action;
+                }
+              }
+              elsif ( $line =~ /^===#.*$/ ) {    # a comment
+                next;
+              }
+              elsif ( $line =~ /^(.*?):(?:\s+)(.*?)(?:\s*)$/ ) {
+                my $tag = $1;
+                my $val = $2;
+
+                $tag =~ s/-//g;
+                # standardize on lc tag
+                $tag   = lc $tag;
+
+                if ( $tag eq 'content' ) {
+                  while ( defined( my $l = shift @lines ) ) {
+                    last if ( $l =~ /^ENDOFCONTENT\s*$/ );
+                    $val .= "\n" . $l;
+                  }
+                  $current_section{$tag} = $val;
+                }
+                elsif ( $tag =~ /(CustomField|CF)(.*)/i ) {
+                  $current_section{CustomFields} = []
+                    unless $current_section{CustomFields};
+                  push @{ $current_section{CustomFields} }, [ $2, $val ];
+                }
+                else {
+                  $current_section{$tag} = $val;
+                }
+              }
+              else {
+                $current_section{perlcode} .= "$line\n";
+              }
+            }
+            # push the last template on to array
+            push @sections, { %current_section };
+        }
+        elsif ( $content ) {
+            RT->Logger->error( "'$Template' is not a Create Tickets template." );
+        }
+    }
+    else {
+        RT->Logger->error( "Couldn't load template '$Template'" );
+
+        $template_object = undef;
+    }
+
+    # add a blank section for new templates or for adding a new ticket section
+    push @sections, { name => 'ADD-NEW-SECTION', active => ( @sections ? 0 : 1 ) };
+}
+</%INIT>
+<%ARGS>
+$TemplateObj => undef
+$QueueObj => undef
+</%ARGS>

--- a/share/html/Admin/Elements/ModifyTemplate
+++ b/share/html/Admin/Elements/ModifyTemplate
@@ -46,63 +46,81 @@
 %#
 %# END BPS TAGGED BLOCK }}}
 <&| /Widgets/TitleBox, class => 'template-info-basics', content_class => 'mx-auto width-lg' &>
-<div class="form-row">
-  <div class="label col-2">
-    <&|/l&>Name</&>:
-  </div>
-  <div class="value col-6">
-    <input type="text" class="form-control" name="Name" value="<%$Name||''%>" size="80" />
-  </div>
-</div>
-
-<div class="form-row">
-  <div class="label col-2">
-    <&|/l&>Description</&>:
-  </div>
-  <div class="value col-6">
-    <input type="text" class="form-control" name="Description" value="<%$Description||''%>" size="80" />
-  </div>
-</div>
-
-<div class="form-row">
-  <div class="label col-2">
-    <&|/l&>Type</&>:
-  </div>
-  <div class="value col-6">
-    <div class="custom-control custom-radio">
-      <input type="radio" name="Type" class="custom-control-input" id="Type-Perl" value="Perl" <% $Type eq "Perl" ? 'checked="checked"' : "" |n %>></input>
-      <label class="custom-control-label" for="Type-Perl"><&|/l&>Perl</&></label><br />
+% if ( $BasicsTab ) {
+  <div class="form-row">
+    <div class="label col-2">
+      <&|/l&>Name</&>:
     </div>
-    <div class="custom-control custom-radio">
-      <input type="radio" name="Type" class="custom-control-input" id="Type-Simple" value="Simple" <% $Type eq "Simple" ? 'checked="checked"' : "" |n %>>
-      <label class="custom-control-label" for="Type-Simple"><&|/l&>Simple</&></label><br />
+    <div class="value col-6">
+      <input type="text" class="form-control" name="Name" value="<%$Name||''%>" size="80" />
     </div>
   </div>
-</div>
-
+  <div class="form-row">
+    <div class="label col-2">
+      <&|/l&>Description</&>:
+    </div>
+    <div class="value col-6">
+      <input type="text" class="form-control" name="Description" value="<%$Description||''%>" size="80" />
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="label col-2">
+      <&|/l&>Type</&>:
+    </div>
+    <div class="value col-6">
+      <div class="custom-control custom-radio">
+        <input type="radio" name="Type" class="custom-control-input" id="Type-Perl" value="Perl" <% $Type eq "Perl" ? 'checked="checked"' : "" |n %>></input>
+        <label class="custom-control-label" for="Type-Perl"><&|/l&>Perl</&></label><br />
+      </div>
+      <div class="custom-control custom-radio">
+        <input type="radio" name="Type" class="custom-control-input" id="Type-Simple" value="Simple" <% $Type eq "Simple" ? 'checked="checked"' : "" |n %>>
+        <label class="custom-control-label" for="Type-Simple"><&|/l&>Simple</&></label><br />
+      </div>
+      <div class="custom-control custom-radio">
+        <input type="radio" name="Type" class="custom-control-input" id="Type-Create" value="Create" <% $Type eq "Create" ? 'checked="checked"' : "" |n %>>
+        <label class="custom-control-label" for="Type-Create"><&|/l&>Create</&></label><br />
+      </div>
+    </div>
+  </div>
+% }
+% else {
+  <input type="hidden" class="hidden" name="Name" value="<% $Name || '' %>" />
+  <input type="hidden" class="hidden" name="Description" value="<% $Description || '' %>" />
+  <input type="hidden" class="hidden" name="Type" value="<% $Type || '' %>" />
+% }
 <div class="form-row">
+% if ( $ContentTab && ( $Type eq 'Create' ) ) {
+  <div class="col-12">
+    <& /Admin/Elements/ModifyCreateTemplate,
+      TemplateObj => $TemplateObj,
+      QueueObj    => $QueueObj,
+      &>
+ </div>
+% }
+% elsif ( $ContentTab || $AdvancedTab ) {
   <div class="label col-2">
     <&|/l&>Content</&>:
   </div>
   <div class="value col-8">
-    <textarea name="Content" class="form-control" rows="25" cols="80" wrap="soft">
-<%$Content||''%></textarea>
+    <textarea name="Content" class="form-control" rows="25" cols="80" wrap="soft"><% $Content || '' %></textarea>
   </div>
+% }
 </div>
 </&>
-
 <%INIT>
-
 unless ($Type) {
     $Type = $session{'CurrentUser'}->HasRight(Right => 'ExecuteCode', Object => $RT::System) ?
         'Perl' : 'Simple';
 }
-
+my $BasicsTab = ( $ContentTab || $AdvancedTab ) ? 0 : 1;
 </%INIT>
-
 <%ARGS>
 $Name => ''
 $Description => ''
 $Content => ''
 $Type => ''
+$TemplateObj => undef
+$QueueObj => undef
+$ContentTab => ''
+$AdvancedTab => ''
 </%ARGS>

--- a/share/html/Admin/Global/Template.html
+++ b/share/html/Admin/Global/Template.html
@@ -56,13 +56,18 @@
 <input type="hidden" class="hidden" name="Template" value="<%$TemplateObj->Id%>" />
 % }
 
-%# hang onto the queue id
+%# hang onto the queue id and tab setting
 <input type="hidden" class="hidden" name="Queue" value="<%$Queue%>" />
+<input type="hidden" class="hidden" name="ContentTab" value="<%$ContentTab%>" />
+<input type="hidden" class="hidden" name="AdvancedTab" value="<%$AdvancedTab%>" />
 <& /Admin/Elements/ModifyTemplate,
     Name        => $TemplateObj->Name // $ARGS{Name},
     Description => $TemplateObj->Description // $ARGS{Description},
     Content     => $TemplateObj->Content // $ARGS{Content},
     Type        => $TemplateObj->Type // $ARGS{Type},
+    TemplateObj => $TemplateObj,
+    ContentTab  => $ContentTab,
+    AdvancedTab => $AdvancedTab,
 &>
   <div class="form-row">
     <div class="col-12">
@@ -113,6 +118,8 @@ if ($Create) {
 $Queue => ''
 $Template => ''
 $Create => ''
+$ContentTab => ''
+$AdvancedTab => ''
 $Name => ''
 $Type => ''
 </%ARGS>

--- a/share/html/Admin/Global/Template.html
+++ b/share/html/Admin/Global/Template.html
@@ -93,6 +93,16 @@ if (!$Create) {
 
 if ( $TemplateObj->Id() ) {
     push @results, ProcessTemplateUpdate( TemplateObj => $TemplateObj, ARGSRef => \%ARGS );
+
+    # if this was a new template need to reload the page so the Basics, Content, and Advanced menu options show
+    if ( defined($Template) && $Template eq 'new' ) {
+      my $request_path = $HTML::Mason::Commands::r->path_info;
+      MaybeRedirectForResults(
+          Actions   => \@results,
+          Path      => $request_path,
+          Arguments => { Queue => 0, Template => $TemplateObj->Id, ContentTab => 1, },
+      );
+    }
 } else {
     $Create = 1;
 }

--- a/share/html/Admin/Global/Template.html
+++ b/share/html/Admin/Global/Template.html
@@ -91,15 +91,8 @@ if (!$Create) {
     }
 }
 
-if ($TemplateObj->Id()) {
-    my @attribs = qw( Name Description Queue Type Content );
-    my @aresults = UpdateRecordObject( AttributesRef => \@attribs,
-                                       Object => $TemplateObj,
-                                       ARGSRef => \%ARGS);
-    push @results, @aresults;
-
-    my ($ok, $msg) = $TemplateObj->CompileCheck;
-    push @results, $msg if !$ok;
+if ( $TemplateObj->Id() ) {
+    push @results, ProcessTemplateUpdate( TemplateObj => $TemplateObj, ARGSRef => \%ARGS );
 } else {
     $Create = 1;
 }

--- a/share/html/Admin/Global/Templates.html
+++ b/share/html/Admin/Global/Templates.html
@@ -48,7 +48,6 @@
 <& /Admin/Elements/Header, Title => $title, FeedURI => 'templates' &>
 <& /Elements/Tabs &>
 <& /Admin/Elements/EditTemplates, title => $title, %ARGS &>
-</form>
 <%init>
 my $title = loc("Modify templates which apply to all queues");
 my (@actions);

--- a/share/html/Admin/Queues/Template.html
+++ b/share/html/Admin/Queues/Template.html
@@ -101,15 +101,7 @@ if ( $TemplateObj->Id() ) {
     $Queue    = $TemplateObj->Queue;
     $QueueObj = $TemplateObj->QueueObj;
 
-    my @attribs = qw( Name Description Queue Type Content );
-    my @aresults = UpdateRecordObject( AttributesRef => \@attribs,
-                                       Object        => $TemplateObj,
-                                       ARGSRef       => \%ARGS
-                                     );
-    push @results, @aresults;
-
-    my ( $ok, $msg ) = $TemplateObj->CompileCheck;
-    push @results, $msg if !$ok;
+    push @results, ProcessTemplateUpdate( TemplateObj => $TemplateObj, ARGSRef => \%ARGS );
 } else {
     $Create = 1;
     $QueueObj = RT::Queue->new( $session{'CurrentUser'} );

--- a/share/html/Admin/Queues/Template.html
+++ b/share/html/Admin/Queues/Template.html
@@ -102,6 +102,16 @@ if ( $TemplateObj->Id() ) {
     $QueueObj = $TemplateObj->QueueObj;
 
     push @results, ProcessTemplateUpdate( TemplateObj => $TemplateObj, ARGSRef => \%ARGS );
+
+    # if this was a new template need to reload the page so the Basics, Content, and Advanced menu options show
+    if ( $Template eq 'new' ) {
+        my $request_path = $HTML::Mason::Commands::r->path_info;
+        MaybeRedirectForResults(
+            Actions   => \@results,
+            Path      => $request_path,
+            Arguments => { Queue => $QueueObj->id, Template => $TemplateObj->Id, ContentTab => 1, },
+        );
+    }
 } else {
     $Create = 1;
     $QueueObj = RT::Queue->new( $session{'CurrentUser'} );

--- a/share/html/Admin/Queues/Template.html
+++ b/share/html/Admin/Queues/Template.html
@@ -56,13 +56,19 @@
 <input type="hidden" class="hidden" name="Template" value="<%$TemplateObj->Id%>" />
 % }
 
-%# hang onto the queue id
+%# hang onto the queue id and tab setting
 <input type="hidden" class="hidden" name="Queue" value="<%$Queue%>" />
+<input type="hidden" class="hidden" name="ContentTab" value="<%$ContentTab%>" />
+<input type="hidden" class="hidden" name="AdvancedTab" value="<%$AdvancedTab%>" />
 <& /Admin/Elements/ModifyTemplate,
     Name        => $TemplateObj->Name // $ARGS{Name},
     Description => $TemplateObj->Description // $ARGS{Description},
     Content     => $TemplateObj->Content // $ARGS{Content},
     Type        => $TemplateObj->Type // $ARGS{Type},
+    TemplateObj => $TemplateObj,
+    QueueObj    => $QueueObj,
+    ContentTab  => $ContentTab,
+    AdvancedTab => $AdvancedTab,
 &>
   <div class="form-row">
     <div class="col-12">
@@ -124,6 +130,8 @@ if ($Create) {
 $Queue => ''
 $Template => ''
 $Create => undef
+$ContentTab => ''
+$AdvancedTab => ''
 $Name => undef
 $Type => undef
 </%ARGS>

--- a/t/web/html_template.t
+++ b/t/web/html_template.t
@@ -15,6 +15,7 @@ my $content  = Encode::decode("UTF-8", "测试");
 {
     $m->follow_link_ok( { id => 'admin-global-templates' }, '-> Templates' );
     $m->follow_link_ok( { text => 'Autoreply in HTML' },    '-> Autoreply in HTML' );
+    $m->follow_link_ok( { text => 'Content' },              '-> Content' );
 
     $m->submit_form(
         form_name => 'ModifyTemplate',

--- a/t/web/template.t
+++ b/t/web/template.t
@@ -60,9 +60,11 @@ $m->form_name('ModifyTemplate');
 is($m->value('Type'), 'Perl', 'now that we have ExecuteCode we can update Type to Perl');
 
 { # 21152: Each time you save a Template a newline is chopped off the front
+  # go to Content tab
+  $m->follow_link( text => 'Content' );
+
   $m->form_name('ModifyTemplate');
   my $content;
-
 
   TODO: {
 


### PR DESCRIPTION
There is one issue that definitely needs addressing but I wanted to discuss the best solution. When editing a template via Admin/Queues the Basics, Content, and Advanced menu options are not visible enough to the user. They need to know they are under the page menu Templates option.

The other question I had was whether we should split the Template.html into separate pages for Basics, Content, and Advanced instead of using the ContentTab/AdvancedTab url params.