### PR TITLE
Always quote search value when using "LIKE" op on numerical CF

### DIFF
--- a/lib/RT/SearchBuilder.pm
+++ b/lib/RT/SearchBuilder.pm
@@ -556,10 +556,10 @@ sub _LimitCustomField {
 
         if (   $args{'FIELD'} eq 'Content'
             && blessed $cf
-            && $cf->IsNumeric
+            && $args{'OPERATOR'} !~ m/LIKE/
             && ( !$args{QUOTEVALUE} || Scalar::Util::looks_like_number($args{'VALUE'}) ) )
         {
-            $args{QUOTEVALUE} = 0;
+            $args{QUOTEVALUE} = 0 unless ( $args{'OPERATOR'} =~ m/LIKE/ );
             $args{FUNCTION} = RT->DatabaseHandle->CastAsDecimal( "$args{ALIAS}.$args{FIELD}" );
             return %args;
         }


### PR DESCRIPTION
Without this, on numerical customfield, SQL produced is wrong and crashes (at least on MySQL):

[...]ObjectCustomFieldValues_1.Content+'0') LIKE %'2'% [...]