### PR TITLE
Always quote search value when using "LIKE" op on numerical CF

### DIFF
--- a/lib/RT/SearchBuilder.pm
+++ b/lib/RT/SearchBuilder.pm
@@ -559,7 +559,7 @@ sub _LimitCustomField {
             && $cf->IsNumeric
             && ( !$args{QUOTEVALUE} || Scalar::Util::looks_like_number($args{'VALUE'}) ) )
         {
-            $args{QUOTEVALUE} = 0;
+            $args{QUOTEVALUE} = 0 unless ( $args{'OPERATOR'} =~ m/LIKE/ );
             $args{FUNCTION} = RT->DatabaseHandle->CastAsDecimal( "$args{ALIAS}.$args{FIELD}" );
             return %args;
         }

--- a/lib/RT/SearchBuilder.pm
+++ b/lib/RT/SearchBuilder.pm
@@ -557,9 +557,10 @@ sub _LimitCustomField {
         if (   $args{'FIELD'} eq 'Content'
             && blessed $cf
             && $cf->IsNumeric
+            && $args{'OPERATOR'} !~ m/LIKE/
             && ( !$args{QUOTEVALUE} || Scalar::Util::looks_like_number($args{'VALUE'}) ) )
         {
-            $args{QUOTEVALUE} = 0 unless ( $args{'OPERATOR'} =~ m/LIKE/ );
+            $args{QUOTEVALUE} = 0;
             $args{FUNCTION} = RT->DatabaseHandle->CastAsDecimal( "$args{ALIAS}.$args{FIELD}" );
             return %args;
         }

--- a/t/ticket/search_by_cf_numeric.t
+++ b/t/ticket/search_by_cf_numeric.t
@@ -52,6 +52,10 @@ $tickets->FromSQL(q{Queue = 'General' AND CF.test_cf < CF.test_cf2 });
 is( $tickets->Count,     1,               'Found 1 ticket' );
 is( $tickets->First->id, $tickets[1]->id, 'Found the small ticket' );
 
+$tickets->FromSQL(q{Queue = 'General' AND CF.test_cf LIKE 2 });
+is( $tickets->Count,     1,               'Found 1 ticket' );
+is( $tickets->First->id, $tickets[0]->id, 'Found the big ticket' );
+
 $tickets->FromSQL(q{Queue = 'General'});
 is( $tickets->Count, 2, 'Found 2 tickets' );
 $tickets->OrderByCols( { FIELD => 'CustomField.test_cf' } );


### PR DESCRIPTION
Without this, on numerical customfield, SQL produced is wrong and crashes (at least on MySQL):

[...]ObjectCustomFieldValues_1.Content+'0') LIKE %'2'% [...]