### PR TITLE
fix: importer didn't quote the Groups table for MySQL8

### DIFF
--- a/lib/RT/Migrate/Importer.pm
+++ b/lib/RT/Migrate/Importer.pm
@@ -632,7 +632,7 @@ sub CloseStream {
     # Groups
     $self->RunSQL(<<'EOF');
 INSERT INTO CachedGroupMembers (GroupId, MemberId, Via, ImmediateParentId, Disabled)
-    SELECT Groups.id, Groups.id, 0, Groups.id, Principals.Disabled FROM Groups
+    SELECT Groups.id, Groups.id, 0, Groups.id, Principals.Disabled FROM `Groups`
     LEFT JOIN Principals ON ( Groups.id = Principals.id )
     LEFT JOIN CachedGroupMembers ON (
         Groups.id = CachedGroupMembers.GroupId
@@ -673,7 +673,7 @@ FROM
         AND cgm3.MemberId          = gm2.MemberId
         AND cgm3.Via               = cgm1.id
         AND cgm3.ImmediateParentId = cgm1.MemberId )
-    LEFT JOIN Groups g ON (
+    LEFT JOIN `Groups` g ON (
         cgm1.GroupId = g.id
     )
 WHERE cgm1.GroupId != cgm1.MemberId

--- a/lib/RT/RightsInspector.pm
+++ b/lib/RT/RightsInspector.pm
@@ -276,12 +276,12 @@ sub InnerRoleQuery {
                MIN(InnerRecords.id) AS example_record,
                COUNT(InnerRecords.id)-1 AS other_count
         FROM ACL main
-        JOIN Groups ParentRoles
+        JOIN `Groups` ParentRoles
              ON main.PrincipalId = ParentRoles.id
         JOIN $inner_table InnerRecords
              ON   (ParentRoles.Domain = '$parent_class-Role' AND InnerRecords.$parent_column = ParentRoles.Instance)
                 OR ParentRoles.Domain = 'RT::System-Role'
-        JOIN Groups InnerRoles
+        JOIN `Groups` InnerRoles
              ON  InnerRoles.Instance = InnerRecords.Id
              AND InnerRoles.Name = main.PrincipalType
     ];


### PR DESCRIPTION
Importer.pm and RightsInspector.pm both used unquoted Groups as a table name. I added the backticks (\`Groups\`) so MySQL8 won't choke on this table name. More work may need to be done to fully support other database types.