### PR TITLE
Add Initial callback to /Helpers/Autocomplete/Owners

### DIFF
--- a/share/html/Helpers/Autocomplete/Owners
+++ b/share/html/Helpers/Autocomplete/Owners
@@ -55,6 +55,11 @@ $term => undef
 $max => undef
 </%ARGS>
 <%INIT>
+$m->callback(
+    CallbackName => 'Initial',
+    TermRef      => \$term,
+);
+
 # Only allow certain return fields
 $return = 'Name'
     unless $return =~ /^(?:EmailAddress|Name|RealName|id)$/;


### PR DESCRIPTION
Allow site admins to manipulate the search term for autocompleting owners.