### PR TITLE
Queues only get CustomRoles that apply to tickets

### DIFF
--- a/share/html/Admin/Elements/EditCustomRoles
+++ b/share/html/Admin/Elements/EditCustomRoles
@@ -145,10 +145,12 @@ if ( $UpdateCRs ) {
 $m->callback( CallbackName => 'UpdateExtraFields', Results => \@results, Object => $Object, %ARGS );
 
 my $added_crs = RT::CustomRoles->new( $session{'CurrentUser'} );
+$added_crs->LimitToLookupType(RT::Ticket->CustomFieldLookupType);
 $added_crs->LimitToObjectId($id);
 $added_crs->ApplySortOrder;
 
 my $not_added_crs = RT::CustomRoles->new( $session{'CurrentUser'} );
+$not_added_crs->LimitToLookupType(RT::Ticket->CustomFieldLookupType);
 $not_added_crs->LimitToNotAdded( $id );
 
 my $format = RT->Config->Get('AdminSearchResultFormat')->{'CustomRoles'};


### PR DESCRIPTION
/Admin/Queues/CustomRoles.html currently always shows all custom roles regardless of whether they apply to tickets or not, even showing them as applied, if they are applied to another object type (i.e. asset catalog) which has the same id.

I followed the lead of other code dealing with CustomRoles, and (ab?)used the CustomFieldLookupType method to get the applicable LookupType.

This hard-codes EditCustomRoles to only work for administering queues, but that's all it's currently used for anyway.


