### PR TITLE
Use Time::HiRes to ensure we can find Time::HiRes::time

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -84,6 +84,7 @@ use RT::Shortener;
 use RT::Interface::Web::ReportsRegistry;
 use MIME::Base64;
 use Digest::SHA 'sha1_hex';
+use Time::HiRes;
 
 our @SHORTENER_SEARCH_FIELDS
     = qw/Class ObjectType BaseQuery Query Format RowsPerPage Order OrderBy ExtraQueryParams ResultPage/;


### PR DESCRIPTION
Without this t/99-policy.t fails for me with:

```
  Failed test 'etc/upgrade/4.3.2/content syntax is OK'
  at t/99-policy.t line 120.
         got: 'Undefined subroutine &Time::HiRes::time called at lib/RT/Interface/Web.pm line 1631.
Compilation failed in require at lib/RT/Template.pm line 83. BEGIN failed--compilation aborted at lib/RT/Template.pm line 83.
Compilation failed in require at lib/RT/Scrip.pm line 76. BEGIN failed--compilation aborted at lib/RT/Scrip.pm line 76.
...
```

and a few other modules.