### PR TITLE
Add EndOfPage callback on article display page

### DIFF
--- a/share/html/Articles/Article/Display.html
+++ b/share/html/Articles/Article/Display.html
@@ -74,6 +74,9 @@
 <&| /Widgets/TitleBox, title => loc('Topics'), class => 'article-topics', &>
 <& Elements/ShowTopics, article => $article &>
 </&>
+
+% $m->callback( %ARGS, CallbackName => 'EndOfPage', ArticleObj => $article );
+
 <%init>
 
 my $article = RT::Article->new( $session{'CurrentUser'} );


### PR DESCRIPTION
Adding a callback lets extensions append additional elements.

This follows the callback pattern of `Ticket/Display.html:EndOfPage`:
  * Pass `%ARGS`
  * Pass the associated article as `ArticleObj` (cf ticket as `TicketObj`)
  * Located as "last" line of display component (below `ShowTopics`)

I am happy to tailor as the project prefers.