### PR TITLE
Only set Resolved date when transitioning to inactive

### DIFF
--- a/lib/RT/Ticket.pm
+++ b/lib/RT/Ticket.pm
@@ -2579,9 +2579,14 @@ sub _SetStatus {
         );
     }
 
+    my $raw_resolved = RT::Date->new(RT->SystemUser);
+    $raw_resolved->Set(Format => 'ISO', Value => $self->__Value('Resolved'));
+
     # When we close a ticket, set the 'Resolved' attribute to now.
     # It's misnamed, but that's just historical.
-    if ( $args{NewLifecycle}->IsInactive($args{Status}) ) {
+    if ( ( !$raw_resolved->IsSet || !$args{Lifecycle}->IsInactive($old) )
+        && $args{NewLifecycle}->IsInactive( $args{Status} ) )
+    {
         $self->_Set(
             Field             => 'Resolved',
             Value             => $now->ISO,


### PR DESCRIPTION
In our RT instance we have multiple inactive states: resolved and closed. When work is completed on a ticket it is marked as resolved, and the Resolved date is updated accordingly. At a later stage the ticket is moved from resolved to closed, which prevents it being re-opened.

Currently this change from resolved to closed changes the Resolved date again. With this change, the Resolved date is only set if transitioning from a non-inactive state to inactive (or the Resolved date isn't set).