### PR TITLE
Add callbacks for link editing and display

### DIFF
--- a/share/html/Elements/EditLink
+++ b/share/html/Elements/EditLink
@@ -53,6 +53,9 @@
   <input type="checkbox" class="checkbox form-check-input" id="DeleteLink-<%$Link->Base%>-<%$Link->Type%>-" name="DeleteLink-<%$Link->Base%>-<%$Link->Type%>-" value="1" />
   <label class="form-check-label" for="DeleteLink-<%$Link->Base%>-<%$Link->Type%>-"><& ShowLink, URI => $Link->BaseURI &></label>
 % }
+
+% $m->callback( CallbackName => 'AfterLinkInputs', Link => $Link, Mode => $Mode, ARGSRef => \%ARGS );
+
 </div>
 
 <%INIT>

--- a/share/html/Elements/ShowLinksOfType
+++ b/share/html/Elements/ShowLinksOfType
@@ -48,6 +48,9 @@
 <ul>
 % for my $link (@not_tickets, @active, @inactive) {
 <li><& ShowLink, URI => $link->$ModeURI &>
+
+% $m->callback( CallbackName => 'AfterShowLink', Link => $link, ARGSRef => \%ARGS );
+
 <%perl>
     next unless $Recurse;
 


### PR DESCRIPTION
Two new callbacks to help customize link presentation:

  * `AfterShowLink` in `Elements/ShowLinksOfType`
  * `AfterLinkInputs` in `Elements/EditLink`

I am happy to rework as needed.