### PR TITLE
Support WWW::Mechanize v2.20

### DIFF
--- a/t/web/admin_groups.t
+++ b/t/web/admin_groups.t
@@ -119,11 +119,11 @@ ok( $m->login(), 'logged in' );
 
     $m->get_ok( $url . '/Admin/Groups/index.html' );
     ok( $m->form_name( 'GroupsAdmin' ), 'found the filter admin groups form');
-    $m->select( GroupField => 'Name', GroupOp => 'LIKE' );
+    $m->select( GroupField => 'Name', 1, GroupOp => 'LIKE' );
     $m->field( GroupString => 'Group' );
-    $m->select( GroupField2 => 'CustomField: '.$cf_1->Name, GroupOp2 => 'LIKE' );
+    $m->select( GroupField2 => 'CustomField: '.$cf_1->Name, 1, GroupOp2 => 'LIKE' );
     $m->field( GroupString2 => 'one' );
-    $m->select( GroupField3 => 'CustomField: '.$cf_2->Name, GroupOp3 => 'LIKE' );
+    $m->select( GroupField3 => 'CustomField: '.$cf_2->Name, 1, GroupOp3 => 'LIKE' );
     $m->field( GroupString3 => 'two' );
     $m->click( 'Go' );
 
@@ -135,9 +135,9 @@ ok( $m->login(), 'logged in' );
 
     diag 'Test NULL value searches';
     ok( $m->form_name( 'GroupsAdmin' ), 'found the filter admin groups form');
-    $m->select( GroupField => 'Name', GroupOp => 'LIKE' );
+    $m->select( GroupField => 'Name', 1, GroupOp => 'LIKE' );
     $m->field( GroupString => 'Group' );
-    $m->select( GroupField2 => 'CustomField: '.$cf_2->Name, GroupOp2 => 'is' );
+    $m->select( GroupField2 => 'CustomField: '.$cf_2->Name, 1, GroupOp2 => 'is' );
     $m->field( GroupString2 => 'NULL' );
     $m->field( GroupString3 => '' );
     $m->click( 'Go' );
@@ -146,7 +146,7 @@ ok( $m->login(), 'logged in' );
 
     ok( $groups[0]->SetDescription('group1') );
     $m->form_name( 'GroupsAdmin' );
-    $m->select( GroupField2 => 'Description', GroupOp2 => 'is' );
+    $m->select( GroupField2 => 'Description', 1, GroupOp2 => 'is' );
     $m->field( GroupString2 => 'NULL' );
     $m->click( 'Go' );
     $m->text_lacks( $_->Name ) for $groups[0];

--- a/t/web/admin_user.t
+++ b/t/web/admin_user.t
@@ -118,11 +118,11 @@ $users[2]->AddCustomFieldValue( Field => $cf_3->id, Value => 'three' );
 
 $m->get_ok( $url . '/Admin/Users/index.html' );
 ok( $m->form_name( 'UsersAdmin' ), 'found the filter admin users form');
-$m->select( UserField => 'Name', UserOp => 'LIKE' );
+$m->select( UserField => 'Name', 1, UserOp => 'LIKE' );
 $m->field( UserString => 'user' );
-$m->select( UserField2 => 'CustomField: '.$cf_1->Name, UserOp2 => 'LIKE' );
+$m->select( UserField2 => 'CustomField: '.$cf_1->Name, 1, UserOp2 => 'LIKE' );
 $m->field( UserString2 => 'one' );
-$m->select( UserField3 => 'CustomField: '.$cf_2->Name, UserOp3 => 'LIKE' );
+$m->select( UserField3 => 'CustomField: '.$cf_2->Name, 1, UserOp3 => 'LIKE' );
 $m->field( UserString3 => 'two' );
 $m->click( 'Go' );
 
@@ -134,7 +134,7 @@ $m->content_lacks( $users[3]->Name );
 
 diag 'Test NULL value searches';
 $m->form_name( 'UsersAdmin' );
-$m->select( UserField2 => 'CustomField: '.$cf_2->Name, UserOp2 => 'is' );
+$m->select( UserField2 => 'CustomField: '.$cf_2->Name, 1, UserOp2 => 'is' );
 $m->field( UserString2 => 'NULL' );
 $m->field( UserString3 => '' );
 $m->click( 'Go' );
@@ -143,7 +143,7 @@ $m->text_contains( $_->Name ) for @users[0,3];
 
 ok( $users[0]->SetRealName('user1') );
 $m->form_name( 'UsersAdmin' );
-$m->select( UserField2 => 'Real Name', UserOp2 => 'is' );
+$m->select( UserField2 => 'Real Name', 1, UserOp2 => 'is' );
 $m->field( UserString2 => 'NULL' );
 $m->click( 'Go' );
 $m->text_lacks( $_->Name ) for $users[0];


### PR DESCRIPTION
The select method now requires the second element to be the occurrence of the form to select. As it now supports working on not just the first form that matches. See:

  https://metacpan.org/dist/WWW-Mechanize/changes

Fixes: https://rt.bestpractical.com/Ticket/Display.html?id=38076