### PR TITLE
RT6 Inline Images Broken by rtname Containing Whitespace

### DIFF
--- a/lib/RT/Interface/Web.pm
+++ b/lib/RT/Interface/Web.pm
@@ -2436,7 +2436,11 @@ sub ExtractImages {
             }
 
             if ($content) {
-                my $cid = sha1_hex($content) . '@' . RT->Config->Get('rtname');
+
+                ## HOTFIX rtname containing whitespace
+                my $rtnameclean = RT->Config->Get('rtname');
+                $rtnameclean =~ s/\s/_/g ;
+                my $cid = sha1_hex($content) . '@' . $rtnameclean;
                 push @images, { cid => $cid, content => $content, content_type => $content_type } unless $added{$cid}++;
                 return "cid:$cid";
             }


### PR DESCRIPTION
When the $rtname variable contains a blank space, the inline images you send are broken due to the way rt parses this variable, resulting in the email recipient being unable to view the images because they are not referenced correctly.