### PR TITLE
Update queries in NewestArticles and UpdatedArticles templates to match their purpose

### DIFF
--- a/share/html/Articles/Elements/NewestArticles
+++ b/share/html/Articles/Elements/NewestArticles
@@ -70,6 +70,6 @@ $MyArticles = RT::Articles->new($session{'CurrentUser'});
 $MyArticles->Limit(FIELD => 'Class', OPERATOR => 'IN', VALUE => \@classes)
     if @classes;
 $MyArticles->RowsPerPage($rows);
-$MyArticles->OrderBy(FIELD => 'LastUpdated', ORDER => 'DESC');
+$MyArticles->OrderBy(FIELD => 'Created', ORDER => 'DESC');
 
 </%INIT>

--- a/share/html/Articles/Elements/UpdatedArticles
+++ b/share/html/Articles/Elements/UpdatedArticles
@@ -71,6 +71,6 @@ $MyArticles->Limit(FIELD => 'Class', OPERATOR => 'IN', VALUE => \@classes)
     if @classes;
 $MyArticles->Limit(FIELD => 'Created', OPERATOR => '!=', VALUE => 'LastUpdated', QUOTEVALUE => 0 );
 $MyArticles->RowsPerPage($rows);
-$MyArticles->OrderBy(FIELD => 'Created', ORDER => 'DESC');
+$MyArticles->OrderBy(FIELD => 'LastUpdated', ORDER => 'DESC');
 
 </%INIT>


### PR DESCRIPTION
Fixes https://rt.bestpractical.com/Ticket/Display.html?id=38126

It looks like ever since these template elements were introduced, their queries have been flipped, so that "most recent" actually shows "newest", and "newest" shows "most recent". This PR swaps them so that the query matches the name/description/title.