### PR TITLE
Missing RT::Base requires

### DIFF
--- a/lib/RT/Shredder/Constants.pm
+++ b/lib/RT/Shredder/Constants.pm
@@ -111,6 +111,7 @@ use constant {
     WIPED     => 0x020,
 };
 
+require RT::Base;
 RT::Base->_ImportOverlays();
 
 1;


### PR DESCRIPTION
Without this we get errors like the following when testing compilation of modules in extensions (like RT::Extension::MergeUsers):

```
   # Can't locate object method "_ImportOverlays" via package "RT::Base" (perhap
s you forgot to load "RT::Base"?) at /usr/share/request-tracker5/lib/RT/Shredder
/Constants.pm line 114.
   # Compilation failed in require at /usr/share/request-tracker5/lib/RT/Shredde
r.pm line 232.
   # BEGIN failed--compilation aborted at /usr/share/request-tracker5/lib/RT/Shr
edder.pm line 232.
   ...
```

Full logs from a failed run is here: https://ci.debian.net/packages/r/rt-extension-mergeusers/testing/amd64/69166980/
