### PR TITLE
Handle GnuPG 2.4.9

### DIFF
--- a/lib/RT/Test/Crypt.pm
+++ b/lib/RT/Test/Crypt.pm
@@ -61,7 +61,7 @@ use 5.010;
 our @EXPORT =
   qw(create_a_ticket update_ticket cleanup_headers set_queue_crypt_options 
           check_text_emails send_email_and_check_transaction
-          create_and_test_outgoing_emails
+          create_and_test_outgoing_emails gnupg_version
           );
 
 our $UsingGnuPG = 0;

--- a/t/security/CVE-2012-4735-incoming-encryption-header.t
+++ b/t/security/CVE-2012-4735-incoming-encryption-header.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use version;
 
 use RT::Test::Crypt GnuPG => 1, tests => undef;
 use Test::Warn;
@@ -60,13 +61,19 @@ EOF
         ($status, $id) = RT::Test->send_via_mailgate($mail);
         ok $id, "created a ticket";
 
-        like($warnings[0], qr/(?:keyring|keybox) .* created/, 'GnuPG warning');
-        like($warnings[1], qr/Failure during GnuPG data: No data has been found\. The reason is 'Invalid packet found'/, 'GnuPG warning');
-        like($warnings[2], qr/Failure during GnuPG data: No data has been found\. The reason is 'No armored data'/, 'GnuPG warning');
+        like($warnings[0], qr/(?:keyring|keybox) .* created/, 'GnuPG warning (created)');
+        like($warnings[1], qr/Failure during GnuPG data: No data has been found\. The reason is 'Invalid packet found'/, 'GnuPG warning (invalid packet)');
 
-        # GnuPG 2.4.5+ issues another warning for gpg-exit
-        if ( $warnings[3] ) {
-            like($warnings[3], qr/Failure during GnuPG gpg-exit: Failed to gpg-exit/, 'GnuPG warning');
+        my $gnupg_version = RT::Test::Crypt->gnupg_version;
+
+        # GnuPG 2.4.9+ removes the "No armored data" warning.
+        if ($gnupg_version < version->parse('2.4.9')) {
+            like($warnings[2], qr/Failure during GnuPG data: No data has been found\. The reason is 'No armored data'/, 'GnuPG warning (no armored data)');
+        }
+
+        # GnuPG 2.4.5+ issues a final warning for gpg-exit
+        if ($gnupg_version >= version->parse('2.4.5')) {
+            like($warnings[-1], qr/Failure during GnuPG gpg-exit: Failed to gpg-exit/, 'GnuPG warning (gpg-exit)');
         }
     }
 


### PR DESCRIPTION
GnuPG 2.4.9 fixes possible memory corruption in armor parsing[0] it appears that this has also changed the warnings emitted. This test now fails:

```
  t/seecurity/CVE-2012-4735-incoming-encryption-header.t .. # GnuPG --homedir /tmp/xqR91djkdB
  ok 1 - created a ticket
  ok 2 - loaded ticket
  ok 3 - Found the right attachment
  ok 4 - Incoming encryption header is removed
  ok 5 - Incoming signature header is removed
  ok 6 - created a ticket
  ok 7 - GnuPG warning
  ok 8 - GnuPG warning
  not ok 9 - GnuPG warning

  #   Failed test 'GnuPG warning'
  #   at t/security/CVE-2012-4735-incoming-encryption-header.t line 65.
  #                   'Failure during GnuPG gpg-exit: Failed to gpg-exit
  # '
  #     doesn't match '(?^:Failure during GnuPG data: No data has been found\. The reason is 'No armored data')'
  ok 10 - loaded ticket
  ok 11 - Found the right attachment
  ok 12 - Incoming encryption header is removed
  ok 13 - Incoming signature header is removed
  ok 14 - no warnings
  1..14
```

These are the warnings emitted:

```
  $VAR1 = [
            'gpg: keybox \'/tmp/rRZPP1xcq3/pubring.kbx\' created
  gpg: invalid radix64 character 5F skipped
  gpg: invalid radix64 character 5F skipped
  gpg: invalid radix64 character 2E skipped
  gpg: [don\'t know]: invalid packet (ctb=4e)
  ',
            'Failure during GnuPG data: No data has been found. The reason is \'Invalid packet found\'
  ',
            'Failure during GnuPG gpg-exit: Failed to gpg-exit
  '
          ];
```

Let's only look for the 'No armored data' on < 2.4.9.

Reported in Debian as part of our regular QA processes:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1130943

[0] https://github.com/gpg/gnupg/blob/6cd241007f390a4be8f18982783e79e7cfb42c5f/NEWS#L1