### PR TITLE
Fix scroll/focus shift on htmx navigation

### DIFF
--- a/share/static/js/util.js
+++ b/share/static/js/util.js
@@ -1796,3 +1796,15 @@ jQuery.fn.combobox.Constructor.prototype.clearElement = function () {
 
 htmx.config.includeIndicatorStyles = false;
 htmx.config.scrollBehavior = 'smooth';
+
+// Disable automatic scroll-to-content on boosted navigation
+// which causes unwanted viewport shifts when combined with menu expansion
+htmx.config.scrollIntoViewOnBoost = false;
+
+// Scroll to top only on full-page boosted navigations (body target),
+// not widget/element reloads which should preserve scroll position
+document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.target === document.body) {
+        window.scrollTo(0, 0);
+    }
+});


### PR DESCRIPTION
When htmx performs boosted navigation (full-page content swap), it defaults to scrolling the viewport to show the new content via scrollIntoViewOnBoost.

Combined with RT's menu expansion on htmx:afterSettle, this causes the viewport to jump around unexpectedly after navigation.

This fix:
1. Disables htmx's automatic scrollIntoViewOnBoost behavior
2. Adds explicit scroll-to-top only for body-target swaps (boosted nav), not for widget/element reloads which should preserve scroll position