### PR TITLE
Encode content to bytes before md5_hex to allow Wide Character with Perl 5.40

### DIFF
--- a/lib/RT/Squish.pm
+++ b/lib/RT/Squish.pm
@@ -81,8 +81,12 @@ sub new {
     bless $self, $class;
 
     my $content = $self->Squish;
+
+    use Encode qw(encode_utf8 is_utf8);
+    my $content_bytes = is_utf8($content) ? encode_utf8($content) : $content;
+    
     $self->Content($content);
-    $self->Key( md5_hex $content );
+    $self->Key( md5_hex $content_bytes );
     $self->ModifiedTime( time() );
     $self->ModifiedTimeString( HTTP::Date::time2str( $self->ModifiedTime ) );
     return $self;


### PR DESCRIPTION
Perl 5.40 enforces strict unicode semantic. Diges::MD5::md_hex() expects bytes but RT:Squish::new passes it a wide character string (eg: )from html/Widgets/SearchSelection)

The fix detects the string's internal encoding and convert it to byte before hashing.

```
Error: Wide character in subroutine entry at /opt/rt6/sbin/../lib/RT/Squish.pm line 85.
                                                  
                                                  Stack:
                                                    [/opt/rt6/sbin/../lib/RT/Squish.pm:85]
                                                    [/opt/rt6/sbin/../lib/RT/Interface/Web.pm:116]
                                                    [/opt/rt6/share/html/Elements/HeaderJavascript:82]
                                                    [/opt/rt6/share/html/Elements/Header:91]
                                                    [/opt/rt6/share/html/Elements/Login:49]
                                                    [/opt/rt6/share/html/NoAuth/Login.html:56]
                                                    [/opt/rt6/sbin/../lib/RT/Interface/Web.pm:455]
                                                    [/opt/rt6/share/html/autohandler:53]
```

Tested on:
  - RT 6.0.2
  - Perl 5.40.1
  - Debian 13 (Trixie)
  - DBD::Pg 3.20.1 / PostgreSQL (Scaleway Serverless SQL)