### PR TITLE
Prevent floating number precision issue

### DIFF
--- a/t/api/attribute-tests.t
+++ b/t/api/attribute-tests.t
@@ -4,8 +4,13 @@ use RT;
 use RT::Test nodata => 1, tests => 34;
 
 
+# runid can't be an integer (why? not sure, maybe casting when stored in the database causes issues?)
+# we need to ensure we don't have a long floating number number as there can be mismatching precision
+# levels between Perl and the database.
+my $runid = int(rand(200) * 100) / 100;
 
-my $runid = rand(200);
+# Make sure we always have a decimal, SQLite (at least) barfs if it is an integer.
+if ($runid == int($runid)) { $runid += .1 };
 
 my $attribute = "squelch-$runid";
 


### PR DESCRIPTION
Some test runs would cause runid to end up with a slightly differing values which caused the tests to fail.

An example of failing test is when $runid was observed to be 153.425536363056, but in the database it is stored as '153.42553636305601'. This caused the Attribute to not be found causing some of the tests to fail.

I see no need for a long fraction to be used, so truncate it.

I haven't seen this issue on the Intel i7 I normally test on, but was reproducible about 50% of the time on an AMD EPYC that a fellow Debian Developer runs package tests on.

I added debugging to lib/RT/Record.pm to see what was happening and got this:

```
ok 15
AddAtribute: RT::User=HASH(0x562dbdb480f0) at /home/puck/request-tracker5/lib/RT/Record.pm line 179, <DATA> line 2112.
$VAR1 = {
          'Name' => '153.425536363056',
          'Content' => 'First',
          'Description' => undef
        };
ok 16 - Object created
# AttrID: 2 - Object created
# runid: 153.425536363056
not ok 17 - got some sort of attribute

#   Failed test 'got some sort of attribute'
#   at t/api/attribute-tests.t line 54.
not ok 18 - undef isa 'RT::Attribute'
```

Check database file:

```
sqlite> select name from Attributes where Content='First';
╭──────────────────────╮
│         Name         │
╞══════════════════════╡
│ '153.42553636305601' │
╰──────────────────────╯
sqlite>
```